### PR TITLE
feat(seo): strengthen article metadata and multilingual discoverability

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import type { ThemeConfig } from '@/types'
 import process from 'node:process'
 
 const defaultLocalSiteUrl = 'http://127.0.0.1:4321'
+const defaultProductionSiteUrl = 'https://code4focus.github.io'
 
 function normalizeSiteUrl(rawUrl: string) {
   try {
@@ -19,7 +20,9 @@ function resolveSiteUrl() {
     return normalizeSiteUrl(envSiteUrl)
   }
 
-  return defaultLocalSiteUrl
+  return process.env.NODE_ENV === 'development'
+    ? defaultLocalSiteUrl
+    : defaultProductionSiteUrl
 }
 
 export const themeConfig: ThemeConfig = {
@@ -36,7 +39,7 @@ export const themeConfig: ThemeConfig = {
     // author name
     author: 'Code4Focus',
     // site url
-    // defaults to localhost for local builds and previews; override with PUBLIC_SITE_URL in deployment environments
+    // defaults to the production site in builds and localhost in development; override with PUBLIC_SITE_URL when needed
     url: resolveSiteUrl(),
     // base path
     // root directory for all pages and assets

--- a/src/content/posts/site/hello-world-en.md
+++ b/src/content/posts/site/hello-world-en.md
@@ -11,7 +11,7 @@ draft: false
 pin: 1
 toc: true
 lang: en
-abbrlink: hello-world-en
+abbrlink: hello-world
 ---
 
 The new blog is now in place.

--- a/src/content/posts/site/hello-world-zh.md
+++ b/src/content/posts/site/hello-world-zh.md
@@ -11,7 +11,7 @@ draft: false
 pin: 1
 toc: true
 lang: zh
-abbrlink: hello-world-zh
+abbrlink: hello-world
 ---
 
 新的博客已经搭起来了。

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -1,7 +1,10 @@
 ---
+import type { Language } from '@/i18n/config'
 import { ClientRouter } from 'astro:transitions'
 import katexCSS from 'katex/dist/katex.min.css?url'
 import { allLocales, base, defaultLocale, themeConfig } from '@/config'
+import { langMap } from '@/i18n/config'
+import { getNextLangPath } from '@/i18n/path'
 import { ui } from '@/i18n/ui'
 import { getPageInfo } from '@/utils/page'
 
@@ -9,13 +12,24 @@ interface Props {
   postTitle?: string
   postDescription?: string
   postSlug?: string
+  postPublished?: Date
+  postUpdated?: Date
+  postTags?: string[]
+  supportedLangs?: Language[]
 }
 
 // Props and Language
-const { postTitle, postDescription, postSlug } = Astro.props
+const {
+  postTitle,
+  postDescription,
+  postSlug,
+  postPublished,
+  postUpdated,
+  postTags = [],
+  supportedLangs = [],
+} = Astro.props
 const { currentLang } = getPageInfo(Astro.url.pathname)
 const currentUI = ui[currentLang as keyof typeof ui] ?? {}
-const lang = currentLang === defaultLocale ? '' : `${currentLang}/`
 
 // Site Configuration
 const { title, subtitle, description, i18nTitle, author, favicon } = themeConfig.site
@@ -25,6 +39,21 @@ const { verification = {}, twitterID = '', googleAnalyticsID = '', umamiAnalytic
 const { google = '', bing = '', yandex = '', baidu = '' } = verification
 const { customGoogleAnalyticsJS = '', customUmamiAnalyticsJS = '' } = themeConfig.preload ?? {}
 
+function getApiflashImageUrl(targetUrl: string, accessKey: string, ttl: string) {
+  const params = new URLSearchParams({
+    access_key: accessKey,
+    url: targetUrl,
+    format: 'png',
+    width: '1500',
+    height: '788',
+    ttl,
+    wait_until: 'network_idle',
+    no_tracking: 'true',
+  })
+
+  return `https://api.apiflash.com/v1/urltoimage?${params.toString()}`
+}
+
 // Site Metadata
 const metaTheme = defaultMode === 'dark' ? darkMode : lightMode
 const siteTitle = i18nTitle ? currentUI.title : title
@@ -32,13 +61,67 @@ const siteSubtitle = i18nTitle ? currentUI.subtitle : subtitle
 const siteDescription = i18nTitle ? currentUI.description : description
 
 // Page Metadata
+const siteOrigin = Astro.site ?? new URL(themeConfig.site.url)
+const canonicalUrl = new URL(`${Astro.url.pathname}${Astro.url.search}`, siteOrigin).toString()
 const pageTitle = postTitle ? `${postTitle} | ${siteTitle}` : `${siteTitle} - ${siteSubtitle}`
 const pageDescription = postDescription || siteDescription
+const feedPrefix = currentLang === defaultLocale ? '' : `/${currentLang}`
+const rssFeedUrl = new URL(`${base}${feedPrefix}/rss.xml`, siteOrigin).toString()
+const atomFeedUrl = new URL(`${base}${feedPrefix}/atom.xml`, siteOrigin).toString()
+const sitemapUrl = new URL(`${base}/sitemap-index.xml`, siteOrigin).toString()
 const pageImage = postSlug
-  ? new URL(`${base}/og/${postSlug}.png`, Astro.url.origin)
-  : apiflashKey
-    ? `https://api.apiflash.com/v1/urltoimage?access_key=${apiflashKey}&url=${Astro.url}&format=png&width=1500&height=788&ttl=259200&wait_until=network_idle&no_tracking=true`
-    : `https://api.apiflash.com/v1/urltoimage?access_key=02a837b6188f4ba0a7fd9fbeff03a83e&url=https://retypeset.radishzz.cc/${lang}&format=png&width=1500&height=788&ttl=604800&wait_until=network_idle&no_tracking=true`
+  ? new URL(`${base}/og/${postSlug}.png`, siteOrigin).toString()
+  : getApiflashImageUrl(
+      canonicalUrl,
+      apiflashKey || '02a837b6188f4ba0a7fd9fbeff03a83e',
+      apiflashKey ? '259200' : '604800',
+    )
+const publisherLogo = favicon.startsWith('http')
+  ? favicon
+  : new URL(`${base}${favicon}`, siteOrigin).toString()
+const localeCode = langMap[currentLang][0]
+const openGraphLocale = localeCode.replace('-', '_')
+const alternateLangs = (supportedLangs.length > 0 ? supportedLangs : allLocales)
+  .filter((lang, index, langs) => langs.indexOf(lang) === index)
+const alternateLinks = alternateLangs.map(lang => ({
+  lang,
+  href: new URL(getNextLangPath(Astro.url.pathname, currentLang, lang), siteOrigin).toString(),
+  hrefLang: langMap[lang][0],
+}))
+const defaultAlternate = alternateLinks.find(link => link.lang === defaultLocale) ?? alternateLinks[0]
+const isArticle = Boolean(postTitle && postPublished)
+const articleUpdated = postUpdated ?? postPublished
+const articleJsonLd = isArticle && postPublished
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      'headline': postTitle,
+      'description': pageDescription,
+      'url': canonicalUrl,
+      'mainEntityOfPage': {
+        '@type': 'WebPage',
+        '@id': canonicalUrl,
+      },
+      'datePublished': postPublished.toISOString(),
+      'dateModified': articleUpdated?.toISOString(),
+      'author': {
+        '@type': 'Organization',
+        'name': author,
+      },
+      'publisher': {
+        '@type': 'Organization',
+        'name': title,
+        'logo': {
+          '@type': 'ImageObject',
+          'url': publisherLogo,
+        },
+      },
+      'image': [pageImage],
+      'inLanguage': localeCode,
+      'keywords': postTags.length > 0 ? postTags.join(', ') : undefined,
+      'isAccessibleForFree': true,
+    }
+  : null
 ---
 
 <head>
@@ -63,26 +146,41 @@ const pageImage = postSlug
 {katexEnabled && <link rel="stylesheet" href={katexCSS} media="print" onload={`this.media='all'`} />}
 
 <!-- Site Links -->
-<link rel="canonical" href={Astro.url} />
-<link rel="sitemap" href={`${base}/sitemap-index.xml`} />
-<link rel="alternate" href={`${base}/rss.xml`} type="application/rss+xml" title="RSS Feed" />
-<link rel="alternate" href={`${base}/atom.xml`} type="application/atom+xml" title="Atom Feed" />
-{allLocales.map(lang => (
+<link rel="canonical" href={canonicalUrl} />
+<link rel="sitemap" href={sitemapUrl} />
+<link rel="alternate" href={rssFeedUrl} type="application/rss+xml" title="RSS Feed" />
+<link rel="alternate" href={atomFeedUrl} type="application/atom+xml" title="Atom Feed" />
+{alternateLinks.map(({ href, hrefLang }) => (
   <link
     rel="alternate"
-    href={`${Astro.url.origin}${base}${lang === defaultLocale ? '' : `/${lang}/`}`}
-    hreflang={lang === 'zh-tw' ? 'zh-TW' : lang}
+    href={href}
+    hreflang={hrefLang}
   />
 ))}
+{defaultAlternate && <link rel="alternate" href={defaultAlternate.href} hreflang="x-default" />}
 
 <!-- Open Graph -->
 <meta property="og:type" content={postTitle ? 'article' : 'website'} />
-<meta property="og:url" content={Astro.url} />
+<meta property="og:url" content={canonicalUrl} />
+<meta property="og:site_name" content={title} />
+<meta property="og:locale" content={openGraphLocale} />
+{alternateLinks
+  .filter(link => link.lang !== currentLang)
+  .map(link => <meta property="og:locale:alternate" content={link.hrefLang.replace('-', '_')} />)}
 <meta property="og:title" content={pageTitle} />
 <meta property="og:description" content={pageDescription} />
 <meta property="og:image" content={pageImage} />
+<meta name="twitter:title" content={pageTitle} />
+<meta name="twitter:description" content={pageDescription} />
+<meta name="twitter:image" content={pageImage} />
 <meta name="twitter:card" content="summary_large_image" />
 {twitterID && <meta name="twitter:site" content={twitterID} />}
+{twitterID && <meta name="twitter:creator" content={twitterID} />}
+{postTags.length > 0 && <meta name="keywords" content={postTags.join(', ')} />}
+{isArticle && postPublished && <meta property="article:published_time" content={postPublished.toISOString()} />}
+{isArticle && articleUpdated && <meta property="article:modified_time" content={articleUpdated.toISOString()} />}
+{postTags.map(tag => <meta property="article:tag" content={tag} />)}
+{articleJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />}
 
 <!-- Site Verification -->
 {google && <meta name="google-site-verification" content={google} />}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,10 +24,21 @@ interface Props {
   postTitle?: string
   postDescription?: string
   postSlug?: string
+  postPublished?: Date
+  postUpdated?: Date
+  postTags?: string[]
   supportedLangs?: Language[]
 }
 
-const { postTitle, postDescription, postSlug, supportedLangs = [] } = Astro.props
+const {
+  postTitle,
+  postDescription,
+  postSlug,
+  postPublished,
+  postUpdated,
+  postTags,
+  supportedLangs = [],
+} = Astro.props
 const { isPost } = getPageInfo(Astro.url.pathname)
 const fontStyle = themeConfig.global.fontStyle === 'serif' ? 'font-serif' : 'font-sans'
 const MarginBottom = isPost && themeConfig.comment.enabled
@@ -42,7 +53,15 @@ const MarginBottom = isPost && themeConfig.comment.enabled
     isPost ? 'scroll-smooth' : '',
   ]}
 >
-  <Head {postTitle} {postDescription} {postSlug} />
+  <Head
+    {postTitle}
+    {postDescription}
+    {postSlug}
+    {postPublished}
+    {postUpdated}
+    {postTags}
+    {supportedLangs}
+  />
   <body>
     <div
       class="mx-auto max-w-205.848 min-h-vh w-full min-h-dvh"

--- a/src/pages/[...lang]/posts/[slug].astro
+++ b/src/pages/[...lang]/posts/[slug].astro
@@ -86,6 +86,9 @@ const { Content, headings, remarkPluginFrontmatter } = await render(post)
   postTitle={post.data.title}
   postDescription={description}
   postSlug={post.id}
+  postPublished={post.data.published}
+  postUpdated={post.data.updated}
+  postTags={post.data.tags}
   supportedLangs={supportedLangs}
 >
   <article class="heti">


### PR DESCRIPTION
## Summary

- align build-time site URL defaults with production so canonical, feed, and sitemap outputs never emit localhost
- generate page-specific `hreflang`, richer Open Graph and Twitter metadata, and `BlogPosting` JSON-LD for article pages

## Scope

- thread article metadata from post pages into `Head`/`Layout` and emit `article:*` metadata for publish, modify, and tags
- generate current-page alternate URLs for home, tags, and posts, including `x-default` and locale alternates
- unify the hello-world sample slugs so `/posts/hello-world/` and `/en/posts/hello-world/` demonstrate reciprocal article alternates

## Validation

- `bash scripts/verify.sh`

## Issue Links

- Parent: `#23`
- Sub-issue: none

## Risks and Follow-ups

- article-level alternates still depend on translated posts sharing the same `abbrlink`
- markdown export and reuse-oriented follow-up remains in `#24` / `#25`
