### PR TITLE
[codex] feat(deploy): publish site to Cloudflare Pages in parallel with GitHub Pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@
 # Leave unset for local development and local builds; the site defaults to http://127.0.0.1:4321.
 # Set this in CI or your hosting platform for deployed builds, for example:
 # PUBLIC_SITE_URL=https://code4focus.github.io
+# Keep this pointed at the primary GitHub Pages domain even if the same build is also uploaded to Cloudflare Pages.
 PUBLIC_SITE_URL=

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,10 +1,8 @@
-name: Deploy to GitHub Pages
+name: Deploy site to GitHub Pages and Cloudflare Pages
 
 on:
   push:
     branches:
-      - main
-      - master
       - user/code4focus
   workflow_dispatch:
 
@@ -13,12 +11,17 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  PRIMARY_SITE_URL: https://code4focus.github.io
+  CLOUDFLARE_PAGES_PROJECT_NAME: code4focus
+
 concurrency:
-  group: pages
+  group: site-deploy
   cancel-in-progress: true
 
 jobs:
   build:
+    if: github.ref_name == 'user/code4focus'
     runs-on: ubuntu-latest
 
     steps:
@@ -28,12 +31,20 @@ jobs:
       - name: Install, build, and upload site
         uses: withastro/action@v6
         env:
-          PUBLIC_SITE_URL: https://code4focus.github.io
+          PUBLIC_SITE_URL: ${{ env.PRIMARY_SITE_URL }}
         with:
           path: .
           package-manager: pnpm@10.33.0
 
-  deploy:
+      - name: Upload Cloudflare Pages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudflare-pages-dist
+          path: dist
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy-github-pages:
     needs: build
     runs-on: ubuntu-latest
 
@@ -45,3 +56,28 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  deploy-cloudflare-pages:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download Cloudflare Pages artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudflare-pages-dist
+          path: .
+
+      - name: Deploy to Cloudflare Pages
+        id: deployment
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy dist
+            --project-name=${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}
+            --branch=${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Retypeset is a static blog theme based on the [Astro](https://astro.build/) fram
 ## Environment
 
 - Local development and local builds default the canonical site/feed URL to `http://127.0.0.1:4321`.
-- Set `PUBLIC_SITE_URL` in your deployment environment to the final site origin, for example `https://code4focus.github.io`.
+- Set `PUBLIC_SITE_URL` in your deployment environment to the primary site origin, for example `https://code4focus.github.io`.
+- This repository may also mirror the same build to `https://code4focus.pages.dev`, but GitHub Pages remains the default canonical/feed/site URL unless a separate issue changes the primary domain.
 - See [.env.example](.env.example) for the expected variable name.
 
 &emsp;[![Deploy to Netlify](assets/images/deploy-netlify.svg)](https://app.netlify.com/start) [![Deploy to Vercel](assets/images/deploy-vercel.svg)](https://vercel.com/new)


### PR DESCRIPTION
## Summary
- publish the existing Astro build to Cloudflare Pages in parallel with GitHub Pages
- keep GitHub Pages as the primary site identity by preserving `PUBLIC_SITE_URL` and documenting that `code4focus.pages.dev` is only a mirrored deployment target

## Scope
- update the deploy workflow to build once, upload the same `dist` artifact for Cloudflare, and run `cloudflare/wrangler-action@v3` with `wrangler pages deploy`
- narrow production deployment execution to `user/code4focus` so manual dispatches from other refs do not overwrite production
- clarify the primary-domain expectation in `README.md` and `.env.example`

## Validation
- `pnpm verify:repo` ✅
- `actionlint` not run because it is not installed in the local environment

## Issue Links
- Parent: #29
- Sub-issue: #30

## Risks and Follow-ups
- the first GitHub Actions run still needs to confirm the downloaded artifact layout matches `dist/` for the Cloudflare deploy step
- Cloudflare Pages production branch was configured externally and should remain aligned with `user/code4focus`
