### PR TITLE
[codex] fix(deploy): use npm for wrangler action

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: npm
           command: >-
             pages deploy dist
             --project-name=${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}


### PR DESCRIPTION
## Summary
- fix the Cloudflare Pages deploy step by forcing `cloudflare/wrangler-action@v3` to install Wrangler with `npm`
- keep the one-build/two-deploy workflow unchanged

## Scope
- add `packageManager: npm` to the Cloudflare deploy action so the runner no longer requires `pnpm` in that job
- no changes to GitHub Pages deployment or site URL behavior

## Validation
- `bash scripts/verify.sh --skip-build` ✅
- previous online run identified the exact failure: `Unable to locate executable file: pnpm`
- end-to-end validation still depends on the next GitHub Actions run after merge

## Issue Links
- Parent: #29
- Sub-issue: #30

## Risks and Follow-ups
- if Cloudflare deploy still fails after this change, the next likely failure surface is API token/project permissions rather than local tool bootstrap
- `cloudflare/wrangler-action@v3` still emits a future Node 20 deprecation warning on GitHub-hosted runners
