### PR TITLE
[codex] fix(deploy): install pnpm for wrangler action

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -71,13 +71,15 @@ jobs:
           name: cloudflare-pages-dist
           path: .
 
+      - name: Install pnpm for Wrangler
+        run: npm install --global pnpm@10.33.0
+
       - name: Deploy to Cloudflare Pages
         id: deployment
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          packageManager: npm
           command: >-
             pages deploy dist
             --project-name=${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}


### PR DESCRIPTION
## Summary
- install `pnpm` explicitly in the Cloudflare deploy job so `cloudflare/wrangler-action@v3` can use the repository's native package manager
- remove the previous `packageManager: npm` workaround that still failed inside this repo's dependency graph

## Scope
- add a dedicated `npm install --global pnpm@10.33.0` step before the Cloudflare deploy action
- restore the wrangler action to its default package-manager detection path

## Validation
- `bash scripts/verify.sh --skip-build` ✅
- previous online runs failed first because `pnpm` was missing, then because `npm i wrangler` hit a dependency resolution conflict in this repo
- end-to-end validation still depends on the next GitHub Actions run after merge

## Issue Links
- Parent: #29
- Sub-issue: #30

## Risks and Follow-ups
- if Cloudflare still fails after this change, the remaining likely failure surface is Cloudflare API/project behavior rather than tool bootstrap
- `cloudflare/wrangler-action@v3` still emits a future Node 20 deprecation warning on GitHub-hosted runners
