### PR TITLE
[codex] fix(deploy): restore dist path for Cloudflare upload

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cloudflare-pages-dist
-          path: .
+          path: dist
 
       - name: Install pnpm for Wrangler
         run: npm install --global pnpm@10.33.0


### PR DESCRIPTION
## Summary
- download the Cloudflare artifact into `dist/` so the deploy command can find the built site directory
- keep the previous pnpm bootstrap fix in place

## Scope
- change `actions/download-artifact@v4` from `path: .` to `path: dist`
- no change to build output, project name, or branch selection logic

## Validation
- `bash scripts/verify.sh --skip-build` ✅
- previous online run reached the actual deploy command and failed with `ENOENT: no such file or directory, scandir '.../dist'`
- end-to-end validation still depends on the next GitHub Actions run after merge

## Issue Links
- Parent: #29
- Sub-issue: #30

## Risks and Follow-ups
- if Cloudflare still fails after this change, the remaining likely surface is Cloudflare-side API/project behavior rather than local workflow shape
- `cloudflare/wrangler-action@v3` still emits a future Node 20 deprecation warning on GitHub-hosted runners
