### PR TITLE
content: introduce series semantics for ordered writing

### DIFF
--- a/scripts/lib/post-lint.ts
+++ b/scripts/lib/post-lint.ts
@@ -72,6 +72,7 @@ const frontmatterOrder = [
   'description',
   'updated',
   'tags',
+  'series',
   'draft',
   'pin',
   'toc',

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -23,7 +23,16 @@ const posts = defineCollection({
         'Series IDs can only contain lowercase letters, numbers and hyphens',
       ),
       kind: z.enum(postSeriesKinds).optional().default('series'),
-      order: z.number().int().positive().optional(),
+      order: z.preprocess((value) => {
+        if (typeof value === 'string') {
+          const normalized = value.trim()
+          if (/^\d+$/.test(normalized)) {
+            return Number(normalized)
+          }
+        }
+
+        return value
+      }, z.number().int().positive().optional()),
       title: z.string().trim().min(1).optional(),
     }).strict().optional(),
     // Advanced

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,6 +2,7 @@ import { glob } from 'astro/loaders'
 import { z } from 'astro/zod'
 import { defineCollection } from 'astro:content'
 import { allLocales, themeConfig } from '@/config'
+import { postSeriesKinds } from '@/utils/content-semantics'
 
 const posts = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/posts/site' }),
@@ -16,6 +17,15 @@ const posts = defineCollection({
       z.date().optional(),
     ),
     tags: z.array(z.string()).optional().default([]),
+    series: z.object({
+      id: z.string().trim().min(1).regex(
+        /^[a-z0-9-]+$/,
+        'Series IDs can only contain lowercase letters, numbers and hyphens',
+      ),
+      kind: z.enum(postSeriesKinds).optional().default('series'),
+      order: z.number().int().positive().optional(),
+      title: z.string().trim().min(1).optional(),
+    }).strict().optional(),
     // Advanced
     draft: z.boolean().optional().default(false),
     pin: z.number().int().min(0).max(99).optional().default(0),

--- a/src/utils/content-semantics.test.ts
+++ b/src/utils/content-semantics.test.ts
@@ -1,0 +1,115 @@
+/* eslint-disable test/no-import-node-test */
+
+import type { SemanticPostLike } from './content-semantics'
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { buildRelatedPosts, buildSemanticGroups } from './content-semantics'
+
+function createPost(
+  id: string,
+  options: {
+    lang?: 'en' | 'zh'
+    order?: number
+    published: string
+    seriesId?: string
+    seriesKind?: 'series' | 'timeline' | 'evergreen'
+    seriesTitle?: string
+    tags?: string[]
+    title: string
+  },
+): SemanticPostLike {
+  return {
+    id,
+    data: {
+      lang: options.lang ?? 'en',
+      published: new Date(options.published),
+      series: options.seriesId
+        ? {
+            id: options.seriesId,
+            kind: options.seriesKind,
+            order: options.order,
+            title: options.seriesTitle,
+          }
+        : undefined,
+      tags: options.tags ?? [],
+      title: options.title,
+    },
+  }
+}
+
+test('buildSemanticGroups sorts grouped posts by semantic order and preserves languages', () => {
+  const posts = [
+    createPost('series-en-2', {
+      lang: 'en',
+      order: 2,
+      published: '2026-04-02T00:00:00.000Z',
+      seriesId: 'build-notes',
+      seriesKind: 'series',
+      seriesTitle: 'Build Notes',
+      title: 'Part 2',
+    }),
+    createPost('series-zh-1', {
+      lang: 'zh',
+      order: 1,
+      published: '2026-04-01T00:00:00.000Z',
+      seriesId: 'build-notes',
+      seriesKind: 'series',
+      title: '第一部分',
+    }),
+    createPost('series-en-3', {
+      lang: 'en',
+      published: '2026-04-03T00:00:00.000Z',
+      seriesId: 'build-notes',
+      title: 'Part 3',
+    }),
+  ]
+
+  const groups = buildSemanticGroups(posts)
+
+  assert.equal(groups.length, 1)
+  assert.equal(groups[0]?.id, 'build-notes')
+  assert.equal(groups[0]?.title, 'Build Notes')
+  assert.equal(groups[0]?.kind, 'series')
+  assert.deepEqual(groups[0]?.languages, ['zh', 'en'])
+  assert.deepEqual(groups[0]?.posts.map(post => post.id), ['series-zh-1', 'series-en-2', 'series-en-3'])
+})
+
+test('buildRelatedPosts prioritizes shared semantic groups before tag-only matches', () => {
+  const currentPost = createPost('current', {
+    order: 1,
+    published: '2026-04-01T00:00:00.000Z',
+    seriesId: 'roadmap',
+    tags: ['AI', 'Product'],
+    title: 'Roadmap Part 1',
+  })
+  const posts = [
+    currentPost,
+    createPost('same-series-2', {
+      order: 2,
+      published: '2026-04-02T00:00:00.000Z',
+      seriesId: 'roadmap',
+      tags: ['AI'],
+      title: 'Roadmap Part 2',
+    }),
+    createPost('tag-match', {
+      published: '2026-04-05T00:00:00.000Z',
+      tags: ['AI'],
+      title: 'Tag Match',
+    }),
+    createPost('same-series-3', {
+      order: 3,
+      published: '2026-04-03T00:00:00.000Z',
+      seriesId: 'roadmap',
+      tags: ['Product'],
+      title: 'Roadmap Part 3',
+    }),
+  ]
+
+  const relatedPosts = buildRelatedPosts(currentPost, posts, 3)
+
+  assert.deepEqual(relatedPosts.map(post => post.id), [
+    'same-series-2',
+    'same-series-3',
+    'tag-match',
+  ])
+})

--- a/src/utils/content-semantics.ts
+++ b/src/utils/content-semantics.ts
@@ -1,0 +1,158 @@
+import type { Language } from '@/i18n/config'
+
+export const postSeriesKinds = ['series', 'timeline', 'evergreen'] as const
+
+export type PostSeriesKind = (typeof postSeriesKinds)[number]
+
+export interface PostSeriesData {
+  id: string
+  title?: string
+  kind?: PostSeriesKind
+  order?: number
+}
+
+export interface SemanticPostLike {
+  id: string
+  data: {
+    lang?: Language | ''
+    published: Date
+    series?: PostSeriesData
+    tags?: string[]
+    title: string
+  }
+}
+
+export interface PostSemanticGroup<T extends SemanticPostLike = SemanticPostLike> {
+  id: string
+  kind: PostSeriesKind
+  languages: Language[]
+  posts: T[]
+  title: string
+}
+
+function formatSeriesTitle(seriesId: string) {
+  const segments = seriesId
+    .split('-')
+    .map(segment => segment.trim())
+    .filter(Boolean)
+
+  if (segments.length === 0) {
+    return seriesId
+  }
+
+  return segments
+    .map(segment => `${segment[0]!.toUpperCase()}${segment.slice(1)}`)
+    .join(' ')
+}
+
+function getSeriesId(post: SemanticPostLike) {
+  return post.data.series?.id?.trim() ?? ''
+}
+
+function countSharedTags(left: SemanticPostLike, right: SemanticPostLike) {
+  const rightTags = new Set(right.data.tags ?? [])
+  return (left.data.tags ?? []).filter(tag => rightTags.has(tag)).length
+}
+
+export function compareSemanticPosts<T extends SemanticPostLike>(left: T, right: T) {
+  const leftOrder = left.data.series?.order
+  const rightOrder = right.data.series?.order
+
+  if (typeof leftOrder === 'number' && typeof rightOrder === 'number' && leftOrder !== rightOrder) {
+    return leftOrder - rightOrder
+  }
+
+  if (typeof leftOrder === 'number' && typeof rightOrder !== 'number') {
+    return -1
+  }
+
+  if (typeof leftOrder !== 'number' && typeof rightOrder === 'number') {
+    return 1
+  }
+
+  const publishedDiff = left.data.published.valueOf() - right.data.published.valueOf()
+  if (publishedDiff !== 0) {
+    return publishedDiff
+  }
+
+  return left.data.title.localeCompare(right.data.title)
+}
+
+export function buildSemanticGroups<T extends SemanticPostLike>(posts: T[]): PostSemanticGroup<T>[] {
+  const groups = new Map<string, T[]>()
+
+  posts.forEach((post) => {
+    const seriesId = getSeriesId(post)
+    if (!seriesId) {
+      return
+    }
+
+    const current = groups.get(seriesId)
+    if (current) {
+      current.push(post)
+    }
+    else {
+      groups.set(seriesId, [post])
+    }
+  })
+
+  return Array.from(groups.entries(), ([id, groupedPosts]) => {
+    const posts = [...groupedPosts].sort(compareSemanticPosts)
+    const title = posts.find(post => post.data.series?.title?.trim())?.data.series?.title?.trim() ?? formatSeriesTitle(id)
+    const kind = posts.find(post => post.data.series?.kind)?.data.series?.kind ?? 'series'
+    const languages = [...new Set(
+      posts
+        .map(post => post.data.lang)
+        .filter((lang): lang is Language => Boolean(lang)),
+    )]
+
+    return {
+      id,
+      kind,
+      languages,
+      posts,
+      title,
+    }
+  })
+    .sort((left, right) => {
+      const leftLatest = left.posts.at(-1)?.data.published.valueOf() ?? 0
+      const rightLatest = right.posts.at(-1)?.data.published.valueOf() ?? 0
+      return rightLatest - leftLatest || left.title.localeCompare(right.title)
+    })
+}
+
+export function buildRelatedPosts<T extends SemanticPostLike>(
+  currentPost: T,
+  posts: T[],
+  limit = 3,
+) {
+  const currentSeriesId = getSeriesId(currentPost)
+  const relatedPosts: T[] = []
+  const seenIds = new Set([currentPost.id])
+
+  if (currentSeriesId) {
+    posts
+      .filter(post => getSeriesId(post) === currentSeriesId && !seenIds.has(post.id))
+      .sort(compareSemanticPosts)
+      .forEach((post) => {
+        seenIds.add(post.id)
+        relatedPosts.push(post)
+      })
+  }
+
+  posts
+    .filter(post => !seenIds.has(post.id))
+    .map(post => ({ post, sharedTags: countSharedTags(currentPost, post) }))
+    .filter(entry => entry.sharedTags > 0)
+    .sort((left, right) =>
+      right.sharedTags - left.sharedTags
+      || right.post.data.published.valueOf() - left.post.data.published.valueOf()
+      || left.post.data.title.localeCompare(right.post.data.title),
+    )
+    .forEach(({ post }) => {
+      seenIds.add(post.id)
+      relatedPosts.push(post)
+    })
+
+  return relatedPosts.slice(0, limit)
+}

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,10 +1,12 @@
 import type { CollectionEntry } from 'astro:content'
 import type { Language } from '@/i18n/config'
 import type { Post } from '@/types'
+import type { PostSemanticGroup, PostSeriesKind } from '@/utils/content-semantics'
 import { getCollection, render } from 'astro:content'
 import { allLocales, base, defaultLocale } from '@/config'
 import { getLangRouteParam } from '@/i18n/lang'
 import { memoize } from '@/utils/cache'
+import { buildRelatedPosts, buildSemanticGroups } from '@/utils/content-semantics'
 
 const metaCache = new Map<string, { minutes: number, hasCitations: boolean, hasCitationPreview: boolean }>()
 
@@ -175,6 +177,56 @@ async function _getPosts(lang?: Language) {
 }
 
 export const getPosts = memoize(_getPosts)
+
+async function _getSemanticGroups(lang?: Language): Promise<PostSemanticGroup<Post>[]> {
+  const posts = await getPosts(lang)
+  return buildSemanticGroups(posts)
+}
+
+export const getSemanticGroups = memoize(_getSemanticGroups)
+
+async function _getSemanticGroupsByKind(kind: PostSeriesKind, lang?: Language) {
+  const groups = await getSemanticGroups(lang)
+  return groups.filter(group => group.kind === kind)
+}
+
+export const getSemanticGroupsByKind = memoize(_getSemanticGroupsByKind)
+
+async function _getSemanticGroup(seriesId: string, lang?: Language) {
+  const groups = await getSemanticGroups(lang)
+  return groups.find(group => group.id === seriesId) ?? null
+}
+
+export const getSemanticGroup = memoize(_getSemanticGroup)
+
+async function _getSemanticSupportedLangs(seriesId: string): Promise<Language[]> {
+  const posts = await getCollection(
+    'posts',
+    ({ data }) =>
+      !data.draft
+      && data.series?.id === seriesId,
+  )
+
+  return allLocales.filter(locale =>
+    posts.some(post =>
+      post.data.lang === locale || post.data.lang === '',
+    ),
+  )
+}
+
+export const getSemanticSupportedLangs = memoize(_getSemanticSupportedLangs)
+
+export async function getRelatedPosts(currentPost: CollectionEntry<'posts'>, lang?: Language, limit = 3) {
+  const posts = await getPosts(lang)
+  const currentSlug = getPostSlug(currentPost)
+  const relatedSource = posts.find(post => getPostSlug(post) === currentSlug)
+
+  if (!relatedSource) {
+    return []
+  }
+
+  return buildRelatedPosts(relatedSource, posts, limit)
+}
 
 /**
  * Get all non-pinned posts

--- a/src/utils/markdown-export.ts
+++ b/src/utils/markdown-export.ts
@@ -264,6 +264,23 @@ function buildMarkdownFrontmatter(
     post.data.tags.forEach(tag => frontmatterLines.push(`  - ${toYamlScalar(tag)}`))
   }
 
+  if (post.data.series?.id) {
+    frontmatterLines.push('series:')
+    frontmatterLines.push(`  id: ${toYamlScalar(post.data.series.id)}`)
+
+    if (post.data.series.title) {
+      frontmatterLines.push(`  title: ${toYamlScalar(post.data.series.title)}`)
+    }
+
+    if (post.data.series.kind) {
+      frontmatterLines.push(`  kind: ${toYamlScalar(post.data.series.kind)}`)
+    }
+
+    if (typeof post.data.series.order === 'number') {
+      frontmatterLines.push(`  order: ${post.data.series.order}`)
+    }
+  }
+
   frontmatterLines.push('---')
   return frontmatterLines.join('\n')
 }


### PR DESCRIPTION
## Summary
- add `series` frontmatter support with `id`, `kind`, `order`, and `title`
- add build-time semantic grouping and related-post helpers plus focused tests for ordered semantic groups
- export semantic metadata in markdown export and accept quoted numeric `series.order` values from content formatting

## Scope
- content schema and build-time semantic utilities only
- no public series or timeline routes in this PR

## Validation
- `bash scripts/verify.sh`

## Issue Links
- Parent: #63
- Related discovery follow-up: #59

## Risks and Follow-ups
- Public series and timeline surfaces ship separately after this foundation merges.
