### PR TITLE
series: add localized hubs and post-level context

### DIFF
--- a/src/components/Semantic/SemanticGroupCard.astro
+++ b/src/components/Semantic/SemanticGroupCard.astro
@@ -1,0 +1,61 @@
+---
+import type { Language } from '@/i18n/config'
+import type { Post } from '@/types'
+import type { PostSemanticGroup } from '@/utils/content-semantics'
+import PostDate from '@/components/PostDate.astro'
+import SemanticKindBadge from '@/components/Semantic/SemanticKindBadge.astro'
+import { getPostPath, getSeriesPath } from '@/i18n/path'
+import { ui } from '@/i18n/ui'
+
+interface Props {
+  group: PostSemanticGroup<Post>
+  lang: Language
+}
+
+const { group, lang } = Astro.props
+const currentUI = ui[lang]
+const latestPost = group.posts.at(-1)
+---
+
+<article class="border border-secondary/15 rounded-3xl bg-secondary/4 px-4.4 py-4.3 transition-[border-color,background-color] ease-out hover:(border-secondary/28 bg-secondary/6)">
+  <div class="flex flex-wrap items-center gap-2.2">
+    <SemanticKindBadge
+      kind={group.kind}
+      lang={lang}
+    />
+    <span class="text-3 c-secondary/75 font-navbar">
+      {group.posts.length} {currentUI.entries}
+    </span>
+  </div>
+
+  <h3 class="mt-2.5 text-5.2 c-primary font-semibold lg:text-5.6 cjk:tracking-wide">
+    <a
+      href={getSeriesPath(group.id, lang)}
+      class="transition-colors hover:c-primary"
+    >
+      {group.title}
+    </a>
+  </h3>
+
+  {latestPost && (
+    <>
+      <div class="mt-1.5 text-3.15 c-secondary/78 font-time">
+        <PostDate
+          date={latestPost.data.published}
+          updatedDate={latestPost.data.updated}
+          minutes={latestPost.remarkPluginFrontmatter.minutes}
+        />
+      </div>
+
+      <p class="mt-2.4 text-3.5 c-secondary/88 leading-1.55em cjk:text-justify">
+        <span class="c-secondary/70 font-navbar">{currentUI.latest}: </span>
+        <a
+          href={getPostPath(latestPost.data.abbrlink || latestPost.id, lang)}
+          class="transition-colors hover:c-primary"
+        >
+          {latestPost.data.title}
+        </a>
+      </p>
+    </>
+  )}
+</article>

--- a/src/components/Semantic/SemanticKindBadge.astro
+++ b/src/components/Semantic/SemanticKindBadge.astro
@@ -1,0 +1,23 @@
+---
+import type { Language } from '@/i18n/config'
+import type { PostSeriesKind } from '@/utils/content-semantics'
+import { ui } from '@/i18n/ui'
+
+interface Props {
+  kind: PostSeriesKind
+  lang: Language
+}
+
+const { kind, lang } = Astro.props
+const currentUI = ui[lang]
+
+const labelByKind = {
+  series: currentUI.kindSeries,
+  timeline: currentUI.kindTimeline,
+  evergreen: currentUI.kindEvergreen,
+} satisfies Record<PostSeriesKind, string>
+---
+
+<span class="inline-flex items-center border border-secondary/20 rounded-full bg-secondary/5 px-2.6 py-0.7 text-2.9 c-secondary/80 tracking-wide font-navbar">
+  {labelByKind[kind]}
+</span>

--- a/src/components/Semantic/SemanticPostSequence.astro
+++ b/src/components/Semantic/SemanticPostSequence.astro
@@ -1,0 +1,75 @@
+---
+import type { Language } from '@/i18n/config'
+import type { Post } from '@/types'
+import PostDate from '@/components/PostDate.astro'
+import { getPostPath } from '@/i18n/path'
+
+interface Props {
+  posts: Post[]
+  lang: Language
+  compact?: boolean
+  currentPostId?: string
+  showDate?: boolean
+}
+
+const {
+  posts,
+  lang,
+  compact = false,
+  currentPostId = '',
+  showDate = true,
+} = Astro.props
+---
+
+<ol class:list={[compact ? 'space-y-2.6' : 'space-y-4.8 lg:space-y-6.2']}>
+  {posts.map((post, index) => {
+    const slug = post.data.abbrlink || post.id
+    const isCurrent = currentPostId === post.id
+
+    return (
+      <li class:list={[
+        'relative pl-9',
+        compact ? 'min-h-6.5' : 'min-h-8.5',
+      ]}
+      >
+        <span class="absolute left-0 top-0.15 text-2.95 c-secondary/55 font-time">
+          {String(index + 1).padStart(2, '0')}
+        </span>
+
+        <div>
+          {isCurrent
+            ? (
+                <span class:list={[
+                  'inline-block c-primary',
+                  compact ? 'text-3.6 font-medium' : 'text-4.4 font-semibold lg:text-4.8',
+                ]}
+                >
+                  {post.data.title}
+                </span>
+              )
+            : (
+                <a
+                  href={getPostPath(slug, lang)}
+                  class:list={[
+                    'inline-block transition-colors hover:c-primary',
+                    compact ? 'text-3.6 font-medium' : 'text-4.4 font-semibold lg:text-4.8',
+                  ]}
+                >
+                  {post.data.title}
+                </a>
+              )}
+
+          {showDate && (
+            <div class="mt-0.8 text-3.15 c-secondary/78 font-time">
+              <PostDate
+                date={post.data.published}
+                updatedDate={post.data.updated}
+                minutes={post.remarkPluginFrontmatter.minutes}
+              />
+            </div>
+          )}
+        </div>
+      </li>
+    )
+  })}
+</ol>

--- a/src/components/Semantic/SeriesContext.astro
+++ b/src/components/Semantic/SeriesContext.astro
@@ -1,0 +1,62 @@
+---
+import type { Language } from '@/i18n/config'
+import type { Post } from '@/types'
+import type { PostSemanticGroup } from '@/utils/content-semantics'
+import SemanticKindBadge from '@/components/Semantic/SemanticKindBadge.astro'
+import SemanticPostSequence from '@/components/Semantic/SemanticPostSequence.astro'
+import { getSeriesPath } from '@/i18n/path'
+import { ui } from '@/i18n/ui'
+
+interface Props {
+  currentPostId: string
+  group: PostSemanticGroup<Post> | null
+  lang: Language
+}
+
+const { currentPostId, group, lang } = Astro.props
+
+if (!group) {
+  return null
+}
+
+const currentUI = ui[lang]
+const currentIndex = group.posts.findIndex(post => post.id === currentPostId)
+const currentStep = currentIndex >= 0 ? currentIndex + 1 : null
+---
+
+<section class="no-heti my-8 border border-secondary/15 rounded-3xl bg-secondary/4 px-4.6 py-4.6">
+  <div class="flex flex-wrap items-center gap-2.2">
+    <SemanticKindBadge
+      kind={group.kind}
+      lang={lang}
+    />
+    <span class="text-3.05 c-secondary/78 font-navbar">
+      {currentUI.inSeries}
+    </span>
+  </div>
+
+  <div class="mt-2.4 flex flex-wrap items-baseline gap-x-3 gap-y-1.6">
+    <h2 class="text-4.9 c-primary font-semibold lg:text-5.3 cjk:tracking-wide">
+      <a
+        href={getSeriesPath(group.id, lang)}
+        class="transition-colors hover:c-primary"
+      >
+        {group.title}
+      </a>
+    </h2>
+
+    <span class="text-3.1 c-secondary/68 font-time">
+      {currentStep ? `${currentStep} / ${group.posts.length}` : group.posts.length} {currentUI.entries}
+    </span>
+  </div>
+
+  <div class="mt-3.4">
+    <SemanticPostSequence
+      posts={group.posts}
+      lang={lang}
+      compact={true}
+      currentPostId={currentPostId}
+      showDate={false}
+    />
+  </div>
+</section>

--- a/src/content/posts/site/comment-moderation-policy-en.md
+++ b/src/content/posts/site/comment-moderation-policy-en.md
@@ -7,6 +7,11 @@ tags:
   - Comments
   - Community
   - Moderation
+series:
+  id: site-foundations
+  kind: series
+  order: "2"
+  title: Site Foundations
 draft: false
 pin: 0
 toc: true
@@ -56,3 +61,4 @@ If your comment was minimized and you believe that was wrong:
 - explain the original intent of the comment and why the minimization looks incorrect
 
 Review will follow the public policy above instead of an undisclosed private rule set.
+

--- a/src/content/posts/site/comment-moderation-policy-zh.md
+++ b/src/content/posts/site/comment-moderation-policy-zh.md
@@ -7,6 +7,11 @@ tags:
   - Comments
   - Community
   - Moderation
+series:
+  id: site-foundations
+  kind: series
+  order: "2"
+  title: 站点基线记录
 draft: false
 pin: 0
 toc: true
@@ -54,3 +59,4 @@ abbrlink: comment-moderation-policy
 - 简要说明评论原意，以及你认为被误判的原因
 
 我会优先按公开规则复核，而不是让隐藏规则替代说明。
+

--- a/src/content/posts/site/hello-world-en.md
+++ b/src/content/posts/site/hello-world-en.md
@@ -7,6 +7,11 @@ tags:
   - Astro
   - Blogging
   - Typography
+series:
+  id: site-foundations
+  kind: series
+  order: "1"
+  title: Site Foundations
 draft: false
 pin: 1
 toc: true
@@ -51,3 +56,4 @@ The official [Astro documentation](https://astro.build) presents Astro as a fram
 ::cite-def[retypeset-demo]{short="Retypeset demo site"}
 The original [Retypeset demo](https://retypeset.radishzz.cc/en/) shows the typography, spacing, and long-form reading experience that made this theme a strong fit for a writing-focused site.
 ::
+

--- a/src/content/posts/site/hello-world-zh.md
+++ b/src/content/posts/site/hello-world-zh.md
@@ -7,6 +7,11 @@ tags:
   - Astro
   - Blogging
   - Typography
+series:
+  id: site-foundations
+  kind: series
+  order: "1"
+  title: 站点基线记录
 draft: false
 pin: 1
 toc: true
@@ -51,3 +56,4 @@ abbrlink: hello-world
 ::cite-def[retypeset-demo]{short="Retypeset 演示站"}
 [Retypeset 演示站](https://retypeset.radishzz.cc/) 所呈现的字距、留白和长文阅读体验，是我判断这套主题适合写作场景的重要依据。
 ::
+

--- a/src/i18n/path.ts
+++ b/src/i18n/path.ts
@@ -33,6 +33,35 @@ export function getPostPath(slug: string, lang: Language): string {
 }
 
 /**
+ * Get path to the localized series index page
+ *
+ * @param lang Current language code
+ * @returns Path to series index
+ */
+export function getSeriesIndexPath(lang: Language): string {
+  const seriesPath = lang === defaultLocale
+    ? '/series/'
+    : `/${lang}/series/`
+
+  return base ? `${base}${seriesPath}` : seriesPath
+}
+
+/**
+ * Get path to a specific series page with language support
+ *
+ * @param seriesId Series identifier
+ * @param lang Current language code
+ * @returns Path to series detail page
+ */
+export function getSeriesPath(seriesId: string, lang: Language): string {
+  const seriesPath = lang === defaultLocale
+    ? `/series/${seriesId}/`
+    : `/${lang}/series/${seriesId}/`
+
+  return base ? `${base}${seriesPath}` : seriesPath
+}
+
+/**
  * Generate localized path based on current language
  *
  * @param path Path to localize

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -5,9 +5,18 @@ interface Translation {
   subtitle: string
   description: string
   posts: string
+  series: string
+  seriesDescription: string
+  seriesEmpty: string
+  inSeries: string
+  entries: string
+  latest: string
   tags: string
   about: string
   toc: string
+  kindSeries: string
+  kindTimeline: string
+  kindEvergreen: string
 }
 
 export const ui: Record<Language, Translation> = {
@@ -16,17 +25,35 @@ export const ui: Record<Language, Translation> = {
     subtitle: 'Build with focus, write with clarity',
     description: 'Code4Focus is a personal blog built with Astro and Retypeset, focused on software, AI, product thinking, and long-term craftsmanship.',
     posts: 'Posts',
+    series: 'Series',
+    seriesDescription: 'Series, timelines, and evergreen reading paths built from first-party content.',
+    seriesEmpty: 'No series have been published in this language yet.',
+    inSeries: 'In this series',
+    entries: 'entries',
+    latest: 'Latest',
     tags: 'Tags',
     about: 'About',
     toc: 'Table of Contents',
+    kindSeries: 'Series',
+    kindTimeline: 'Timeline',
+    kindEvergreen: 'Evergreen',
   },
   zh: {
     title: 'Code4Focus',
     subtitle: '专注地构建，清晰地表达',
     description: 'Code4Focus 是一个使用 Astro 与 Retypeset 构建的个人博客，记录软件工程、AI、产品思考与长期主义相关的内容。',
     posts: '文章',
+    series: '系列',
+    seriesDescription: '由一方内容语义组织起来的系列、时间线与长青阅读路径。',
+    seriesEmpty: '当前语言下还没有可浏览的系列内容。',
+    inSeries: '本系列',
+    entries: '篇',
+    latest: '最新',
     tags: '标签',
     about: '关于',
     toc: '目录',
+    kindSeries: '系列',
+    kindTimeline: '时间线',
+    kindEvergreen: '长青',
   },
 }

--- a/src/pages/[...lang]/posts/[slug].astro
+++ b/src/pages/[...lang]/posts/[slug].astro
@@ -4,13 +4,14 @@ import type { Language } from '@/i18n/config'
 import { render } from 'astro:content'
 import Comment from '@/components/Comment/Index.astro'
 import PostDate from '@/components/PostDate.astro'
+import SeriesContext from '@/components/Semantic/SeriesContext.astro'
 import TagList from '@/components/TagList.astro'
 import BackButton from '@/components/Widgets/BackButton.astro'
 import CitationPreview from '@/components/Widgets/CitationPreview.astro'
 import TOC from '@/components/Widgets/TOC.astro'
 import { getLangFromLocale } from '@/i18n/lang'
 import Layout from '@/layouts/Layout.astro'
-import { getPostPath, getPostStaticPaths } from '@/utils/content'
+import { getPostPath, getPostStaticPaths, getSemanticGroup } from '@/utils/content'
 import { getPostDescription } from '@/utils/description'
 import '@/styles/citation.css'
 
@@ -29,6 +30,9 @@ const slug = post.data.abbrlink || post.id
 const description = getPostDescription(post, 'meta')
 const markdownExportPath = getPostPath(slug, currentLang, 'markdown')
 const { Content, headings, remarkPluginFrontmatter } = await render(post)
+const seriesGroup = post.data.series?.id
+  ? await getSemanticGroup(post.data.series.id, currentLang)
+  : null
 ---
 
 <Layout
@@ -69,6 +73,12 @@ const { Content, headings, remarkPluginFrontmatter } = await render(post)
         minutes={remarkPluginFrontmatter.minutes}
       />
     </div>
+    <!-- Series Context -->
+    <SeriesContext
+      currentPostId={post.id}
+      group={seriesGroup}
+      lang={currentLang}
+    />
     <!-- TOC -->
     {post.data.toc && <TOC headings={headings} />}
     <!-- Content -->

--- a/src/pages/[...lang]/series/[seriesId].astro
+++ b/src/pages/[...lang]/series/[seriesId].astro
@@ -1,0 +1,86 @@
+---
+import type { Language } from '@/i18n/config'
+import SemanticKindBadge from '@/components/Semantic/SemanticKindBadge.astro'
+import SemanticPostSequence from '@/components/Semantic/SemanticPostSequence.astro'
+import { getLangFromLocale, getLangRouteParam } from '@/i18n/lang'
+import { ui } from '@/i18n/ui'
+import Layout from '@/layouts/Layout.astro'
+import { getAllSemanticGroups, getSemanticGroup, getSemanticSupportedLangs } from '@/utils/content'
+import { getPostDescription } from '@/utils/description'
+
+export async function getStaticPaths() {
+  const groups = await getAllSemanticGroups()
+  const paths = await Promise.all(groups.map(async (group) => {
+    const supportedLangs = await getSemanticSupportedLangs(group.id)
+
+    return supportedLangs.map(routeLang => ({
+      params: {
+        lang: getLangRouteParam(routeLang),
+        seriesId: group.id,
+      },
+      props: {
+        seriesId: group.id,
+        supportedLangs,
+      },
+    }))
+  }))
+
+  return paths.flat()
+}
+
+interface Props {
+  seriesId: string
+  supportedLangs: Language[]
+}
+
+const { seriesId, supportedLangs } = Astro.props
+const currentLang = getLangFromLocale(Astro.currentLocale)
+const currentUI = ui[currentLang]
+const group = await getSemanticGroup(seriesId, currentLang)
+
+if (!group) {
+  throw new Error(`Series group "${seriesId}" was not found for language "${currentLang}".`)
+}
+
+const latestPost = group.posts.at(-1)
+const pageDescription = latestPost
+  ? `${group.title} · ${group.posts.length} ${currentUI.entries}. ${getPostDescription(latestPost, 'meta')}`
+  : currentUI.seriesDescription
+---
+
+<Layout
+  postTitle={group.title}
+  postDescription={pageDescription}
+  supportedLangs={supportedLangs}
+>
+  <div class="uno-decorative-line" />
+
+  <section class="mt-5.5 lg:mt-6.5">
+    <div class="flex flex-wrap items-center gap-2.2">
+      <SemanticKindBadge
+        kind={group.kind}
+        lang={currentLang}
+      />
+      <span class="text-3.05 c-secondary/75 font-navbar">
+        {group.posts.length} {currentUI.entries}
+      </span>
+    </div>
+
+    <h2 class="mt-2.6 text-7.2 c-primary font-bold leading-1.18em lg:text-8.3 cjk:tracking-wide">
+      {group.title}
+    </h2>
+
+    {latestPost && (
+      <p class="mt-2.8 text-3.7 c-secondary/86 leading-1.65em lg:max-w-50rem cjk:text-justify lg:text-3.85">
+        {getPostDescription(latestPost, 'meta')}
+      </p>
+    )}
+
+    <div class="mt-5.2 border border-secondary/15 rounded-3xl bg-secondary/3 px-4.6 py-4.8 lg:mt-6.4 lg:px-5.2 lg:py-5.2">
+      <SemanticPostSequence
+        posts={group.posts}
+        lang={currentLang}
+      />
+    </div>
+  </section>
+</Layout>

--- a/src/pages/[...lang]/series/index.astro
+++ b/src/pages/[...lang]/series/index.astro
@@ -1,0 +1,43 @@
+---
+import SemanticGroupCard from '@/components/Semantic/SemanticGroupCard.astro'
+import { allLocales } from '@/config'
+import { getLangFromLocale, getLangRouteParam } from '@/i18n/lang'
+import { ui } from '@/i18n/ui'
+import Layout from '@/layouts/Layout.astro'
+import { getSemanticGroups } from '@/utils/content'
+
+export async function getStaticPaths() {
+  return allLocales.map(lang => ({
+    params: { lang: getLangRouteParam(lang) },
+  }))
+}
+
+const currentLang = getLangFromLocale(Astro.currentLocale)
+const currentUI = ui[currentLang]
+const groups = await getSemanticGroups(currentLang)
+---
+
+<Layout
+  postTitle={currentUI.series}
+  postDescription={currentUI.seriesDescription}
+  supportedLangs={allLocales}
+>
+  <div class="uno-decorative-line" />
+
+  {groups.length > 0
+    ? (
+        <section class="mt-5.5 lg:mt-6.5 space-y-4.4 lg:space-y-5">
+          {groups.map(group => (
+            <SemanticGroupCard
+              group={group}
+              lang={currentLang}
+            />
+          ))}
+        </section>
+      )
+    : (
+        <p class="mt-5.5 text-3.8 c-secondary/86 leading-1.65em lg:mt-6.5 lg:text-4">
+          {currentUI.seriesEmpty}
+        </p>
+      )}
+</Layout>

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -185,6 +185,17 @@ async function _getSemanticGroups(lang?: Language): Promise<PostSemanticGroup<Po
 
 export const getSemanticGroups = memoize(_getSemanticGroups)
 
+async function _getAllSemanticGroups(): Promise<PostSemanticGroup<CollectionEntry<'posts'>>[]> {
+  const posts = await getCollection(
+    'posts',
+    ({ data }) => import.meta.env.DEV || !data.draft,
+  )
+
+  return buildSemanticGroups(posts)
+}
+
+export const getAllSemanticGroups = memoize(_getAllSemanticGroups)
+
 async function _getSemanticGroupsByKind(kind: PostSeriesKind, lang?: Language) {
   const groups = await getSemanticGroups(lang)
   return groups.filter(group => group.kind === kind)
@@ -203,7 +214,7 @@ async function _getSemanticSupportedLangs(seriesId: string): Promise<Language[]>
   const posts = await getCollection(
     'posts',
     ({ data }) =>
-      !data.draft
+      (import.meta.env.DEV || !data.draft)
       && data.series?.id === seriesId,
   )
 

--- a/src/utils/page.ts
+++ b/src/utils/page.ts
@@ -42,6 +42,10 @@ export function isAboutPage(path: string) {
   return matchPageType(path, 'about')
 }
 
+export function isSeriesPage(path: string) {
+  return matchPageType(path, 'series')
+}
+
 // Returns page context with language, page types and localization helper
 export function getPageInfo(path: string) {
   const currentLang = getLangFromPath(path)
@@ -49,6 +53,7 @@ export function getPageInfo(path: string) {
   const isPost = isPostPage(path)
   const isTag = isTagPage(path)
   const isAbout = isAboutPage(path)
+  const isSeries = isSeriesPage(path)
 
   return {
     currentLang,
@@ -56,6 +61,7 @@ export function getPageInfo(path: string) {
     isPost,
     isTag,
     isAbout,
+    isSeries,
     getLocalizedPath: (targetPath: string) =>
       getLocalizedPath(targetPath, currentLang),
   }


### PR DESCRIPTION
## Summary
- add localized series index and detail pages backed by the new semantic grouping model
- add shared series UI primitives and a low-intrusion in-post series context module
- seed the current bilingual site posts with minimal series metadata and localize series copy and routing helpers

## Scope
- series discovery surfaces and post-level series entry points
- builds on the content semantics foundation from #63

## Validation
- `bash scripts/verify.sh`

## Issue Links
- Parent: #59
- Sub-issue: #67
- Dependency: #63

## Risks and Follow-ups
- This PR is stacked on the #63 branch until the content semantics foundation merges.
