### PR TITLE
feat(workflow): finish bilingual pair contract

### DIFF
--- a/scripts/lib/post-lint.ts
+++ b/scripts/lib/post-lint.ts
@@ -7,6 +7,7 @@ import { parseDocument, stringify } from 'yaml'
 import { defaultGlobalToc } from '../../src/config/shared'
 import { langMap } from '../../src/i18n/config'
 import { extractExcerptFromMarkdown, extractPlainTextFromMarkdown } from '../../src/utils/post-excerpt'
+import { getPairedPostKey, getPairedPostSiblingCandidatePaths } from '../../src/utils/post-pairing'
 
 type FocusLang = Language
 type Severity = 'error' | 'warning'
@@ -560,7 +561,11 @@ function getLineNumberForKey(frontmatter: string, key: string) {
   return index >= 0 ? index + 2 : 2
 }
 
-function getPairKey(filePath: string) {
+function getPairKey(filePath: string, profile: ContentProfile) {
+  if (profile === 'post') {
+    return getPairedPostKey(filePath)
+  }
+
   return normalizeFilePathKey(filePath)
     .replace(/\.(?:md|mdx)$/i, '')
     .replace(filenameLangSuffixPattern, '')
@@ -615,7 +620,7 @@ function buildMetadataSnapshot(
   return {
     filePath,
     profile,
-    pairKey: getPairKey(filePath),
+    pairKey: getPairKey(filePath, profile),
     lang: resolvedLang,
     fieldLines,
     values,
@@ -631,7 +636,7 @@ function buildPresenceSnapshot(
   return {
     filePath,
     profile,
-    pairKey: getPairKey(filePath),
+    pairKey: getPairKey(filePath, profile),
     lang,
     fieldLines: {},
     values: {},
@@ -703,14 +708,16 @@ async function collectPairingSnapshots(targetSnapshots: MetadataSnapshot[]) {
   })
 
   for (const snapshot of targetSnapshots) {
-    const candidatePaths = [
-      `${snapshot.pairKey}.md`,
-      `${snapshot.pairKey}.mdx`,
-      ...supportedLanguages.flatMap(lang => [
-        `${snapshot.pairKey}-${lang}.md`,
-        `${snapshot.pairKey}-${lang}.mdx`,
-      ]),
-    ]
+    const candidatePaths = snapshot.profile === 'post'
+      ? getPairedPostSiblingCandidatePaths(snapshot.filePath)
+      : [
+          `${snapshot.pairKey}.md`,
+          `${snapshot.pairKey}.mdx`,
+          ...supportedLanguages.flatMap(lang => [
+            `${snapshot.pairKey}-${lang}.md`,
+            `${snapshot.pairKey}-${lang}.mdx`,
+          ]),
+        ]
 
     for (const candidatePath of candidatePaths) {
       const normalizedCandidate = normalizeFilePathKey(candidatePath)

--- a/scripts/new-post.test.ts
+++ b/scripts/new-post.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable test/no-import-node-test */
+
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import process from 'node:process'
+import { afterEach, test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const tempRoots: string[] = []
+const scriptsDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = dirname(scriptsDir)
+const scriptPath = join(scriptsDir, 'new-post.ts')
+const tsxCliPath = join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs')
+
+afterEach(async () => {
+  while (tempRoots.length > 0) {
+    const tempRoot = tempRoots.pop()
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  }
+})
+
+async function createTempRoot() {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'new-post-'))
+  tempRoots.push(tempRoot)
+  return tempRoot
+}
+
+async function runNewPost(args: string[], cwd: string) {
+  return execFileAsync(
+    process.execPath,
+    [tsxCliPath, scriptPath, ...args],
+    {
+      cwd,
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+      },
+    },
+  )
+}
+
+function getFieldValue(source: string, field: string) {
+  const match = source.match(new RegExp(`^${field}:\\s*(.*)$`, 'm'))
+  return match?.[1] ?? ''
+}
+
+test('new-post preserves the single-file scaffold path', async () => {
+  const tempRoot = await createTempRoot()
+
+  await runNewPost(['solo-post'], tempRoot)
+
+  const createdFile = join(tempRoot, 'src', 'content', 'posts', 'site', 'solo-post.md')
+  const source = await readFile(createdFile, 'utf8')
+
+  assert.match(source, /^title: solo-post$/m)
+  assert.equal(getFieldValue(source, 'lang'), '\'\'')
+  assert.equal(getFieldValue(source, 'abbrlink'), '\'\'')
+})
+
+test('new-post --paired creates zh/en files with shared pair metadata', async () => {
+  const tempRoot = await createTempRoot()
+
+  await runNewPost(['--paired', 'notes/hello-world'], tempRoot)
+
+  const zhFile = join(tempRoot, 'src', 'content', 'posts', 'site', 'notes', 'hello-world-zh.md')
+  const enFile = join(tempRoot, 'src', 'content', 'posts', 'site', 'notes', 'hello-world-en.md')
+  const zhSource = await readFile(zhFile, 'utf8')
+  const enSource = await readFile(enFile, 'utf8')
+
+  assert.equal(getFieldValue(zhSource, 'lang'), 'zh')
+  assert.equal(getFieldValue(enSource, 'lang'), 'en')
+  assert.equal(getFieldValue(zhSource, 'abbrlink'), 'hello-world')
+  assert.equal(getFieldValue(enSource, 'abbrlink'), 'hello-world')
+  assert.equal(getFieldValue(zhSource, 'published'), getFieldValue(enSource, 'published'))
+  assert.match(zhSource, /^title: hello-world$/m)
+  assert.match(enSource, /^title: hello-world$/m)
+})
+
+test('new-post --paired strips a locale suffix from the requested path before creating both files', async () => {
+  const tempRoot = await createTempRoot()
+
+  await runNewPost(['content/routing-notes-en.mdx', '--paired'], tempRoot)
+
+  const zhFile = join(tempRoot, 'src', 'content', 'posts', 'site', 'content', 'routing-notes-zh.mdx')
+  const enFile = join(tempRoot, 'src', 'content', 'posts', 'site', 'content', 'routing-notes-en.mdx')
+
+  assert.equal(getFieldValue(await readFile(zhFile, 'utf8'), 'abbrlink'), 'routing-notes')
+  assert.equal(getFieldValue(await readFile(enFile, 'utf8'), 'abbrlink'), 'routing-notes')
+})
+
+test('new-post --paired fails before creating a partial pair when one target already exists', async () => {
+  const tempRoot = await createTempRoot()
+  const existingEnFile = join(tempRoot, 'src', 'content', 'posts', 'site', 'hello-world-en.md')
+  const missingZhFile = join(tempRoot, 'src', 'content', 'posts', 'site', 'hello-world-zh.md')
+
+  await mkdir(dirname(existingEnFile), { recursive: true })
+  await writeFile(existingEnFile, 'existing-content\n', 'utf8')
+
+  try {
+    await runNewPost(['--paired', 'hello-world'], tempRoot)
+    assert.fail('Expected paired scaffold creation to fail when one target already exists.')
+  }
+  catch (error) {
+    const stderr = typeof error === 'object' && error !== null && 'stderr' in error
+      ? String((error as { stderr: string }).stderr)
+      : ''
+    assert.match(stderr, /File already exists/)
+  }
+
+  assert.equal(await readFile(existingEnFile, 'utf8'), 'existing-content\n')
+  await assert.rejects(readFile(missingZhFile, 'utf8'))
+})

--- a/scripts/new-post.ts
+++ b/scripts/new-post.ts
@@ -1,6 +1,9 @@
 /**
- * Create a new post with frontmatter
- * Usage: pnpm new-post <title>
+ * Create one post file or a paired zh/en site post scaffold.
+ *
+ * Usage:
+ *   pnpm new-post <path>
+ *   pnpm new-post --paired <path>
  */
 
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
@@ -8,27 +11,105 @@ import { basename, dirname, extname, join } from 'node:path'
 import process from 'node:process'
 import { themeConfig } from '../src/config'
 
-// Process file path
-const rawPath = process.argv[2] ?? 'new-post'
-const baseName = basename(rawPath).replace(/\.(md|mdx)$/, '')
-const targetFile = ['.md', '.mdx'].includes(extname(rawPath))
-  ? rawPath
-  : `${rawPath}.md`
-const fullPath = join('src/content/posts/site', targetFile)
+interface CliOptions {
+  paired: boolean
+  rawPath: string
+}
 
-// Check if file already exists
-if (existsSync(fullPath)) {
-  console.error(`❌ File already exists: ${fullPath}`)
+interface PostTarget {
+  abbrlink: string
+  filePath: string
+  lang: string
+  title: string
+}
+
+class HelpExit extends Error {}
+
+const markdownExtensions = new Set(['.md', '.mdx'])
+const contentRoot = join('src', 'content', 'posts', 'site')
+const localeSuffixPattern = /-(en|zh)$/i
+
+function printHelp() {
+  console.log(`Create one post file or a paired zh/en site post scaffold.
+
+Usage:
+  pnpm new-post <path>
+  pnpm new-post --paired <path>
+
+Options:
+  --paired        Create one \`-zh\` file and one \`-en\` file together
+  --help, -h      Show this help text
+`)
+}
+
+function fail(message: string): never {
+  console.error(`❌ ${message}`)
   process.exit(1)
 }
 
-// Create directory structure
-mkdirSync(dirname(fullPath), { recursive: true })
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    paired: false,
+    rawPath: 'new-post',
+  }
 
-// Prepare file content
-const content = `---
-title: ${baseName}
-published: ${new Date().toISOString()}
+  let positionalCount = 0
+
+  for (const arg of argv) {
+    switch (arg) {
+      case '--paired':
+        options.paired = true
+        break
+      case '--help':
+      case '-h':
+        printHelp()
+        throw new HelpExit()
+      default:
+        if (arg.startsWith('-')) {
+          fail(`Unknown argument: ${arg}`)
+        }
+
+        positionalCount += 1
+        if (positionalCount > 1) {
+          fail('Only one path argument is supported.')
+        }
+        options.rawPath = arg
+    }
+  }
+
+  return options
+}
+
+function resolveExtension(rawPath: string) {
+  const requestedExtension = extname(rawPath)
+  return markdownExtensions.has(requestedExtension) ? requestedExtension : '.md'
+}
+
+function stripLocaleSuffix(baseName: string) {
+  return baseName.replace(localeSuffixPattern, '')
+}
+
+function normalizeAbbrlink(baseName: string) {
+  return baseName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function formatFrontmatterValue(value: string) {
+  return value || '\'\''
+}
+
+function createPostContent(options: {
+  abbrlink: string
+  lang: string
+  published: string
+  title: string
+}) {
+  return `---
+title: ${formatFrontmatterValue(options.title)}
+published: ${options.published}
 description: ''
 updated: ''
 tags:
@@ -36,17 +117,98 @@ tags:
 draft: false
 pin: 0
 toc: ${themeConfig.global.toc}
-lang: ''
-abbrlink: ''
+lang: ${formatFrontmatterValue(options.lang)}
+abbrlink: ${formatFrontmatterValue(options.abbrlink)}
 ---
 `
+}
 
-// Write to file
+function buildSingleTarget(rawPath: string): PostTarget {
+  const extension = resolveExtension(rawPath)
+  const targetFile = markdownExtensions.has(extname(rawPath))
+    ? rawPath
+    : `${rawPath}${extension}`
+  const baseName = basename(targetFile, extension)
+
+  return {
+    abbrlink: '',
+    filePath: join(contentRoot, targetFile),
+    lang: '',
+    title: baseName,
+  }
+}
+
+function buildPairedTargets(rawPath: string): PostTarget[] {
+  const extension = resolveExtension(rawPath)
+  const rawTarget = markdownExtensions.has(extname(rawPath))
+    ? rawPath
+    : `${rawPath}${extension}`
+  const relativeDir = dirname(rawTarget) === '.' ? '' : dirname(rawTarget)
+  const rawBaseName = basename(rawTarget, extension)
+  const pairBaseName = stripLocaleSuffix(rawBaseName)
+
+  if (!pairBaseName) {
+    fail(`Invalid paired post path: ${rawPath}`)
+  }
+
+  const abbrlink = normalizeAbbrlink(pairBaseName)
+
+  return ['zh', 'en'].map(lang => ({
+    abbrlink,
+    filePath: join(contentRoot, relativeDir, `${pairBaseName}-${lang}${extension}`),
+    lang,
+    title: pairBaseName,
+  }))
+}
+
+function assertTargetsDoNotExist(targets: PostTarget[]) {
+  const existingTargets = targets.filter(target => existsSync(target.filePath))
+  if (existingTargets.length === 0) {
+    return
+  }
+
+  fail(`File already exists: ${existingTargets.map(target => target.filePath).join(', ')}`)
+}
+
+function writeTargets(targets: PostTarget[]) {
+  const published = new Date().toISOString()
+
+  targets.forEach((target) => {
+    mkdirSync(dirname(target.filePath), { recursive: true })
+    writeFileSync(target.filePath, createPostContent({
+      abbrlink: target.abbrlink,
+      lang: target.lang,
+      published,
+      title: target.title,
+    }))
+  })
+}
+
+function printSuccess(targets: PostTarget[], paired: boolean) {
+  if (!paired) {
+    console.log(`✅ Post created: ${targets[0]!.filePath}`)
+    return
+  }
+
+  console.log(`✅ Paired posts created:`)
+  targets.forEach(target => console.log(target.filePath))
+}
+
 try {
-  writeFileSync(fullPath, content)
-  console.log(`✅ Post created: ${fullPath}`)
+  const options = parseArgs(process.argv.slice(2))
+  const targets = options.paired
+    ? buildPairedTargets(options.rawPath)
+    : [buildSingleTarget(options.rawPath)]
+
+  assertTargetsDoNotExist(targets)
+  writeTargets(targets)
+  printSuccess(targets, options.paired)
 }
 catch (error) {
+  if (error instanceof HelpExit) {
+    process.exit(0)
+  }
+
   console.error('❌ Failed to create post:', error)
   process.exit(1)
 }

--- a/src/components/HomeTimeline.astro
+++ b/src/components/HomeTimeline.astro
@@ -3,6 +3,7 @@ import type { Language } from '@/i18n/config'
 import type { Post } from '@/types'
 import PostDate from '@/components/PostDate.astro'
 import { getPostPath } from '@/i18n/path'
+import { getPostSlug } from '@/utils/content'
 import { getPostDescription } from '@/utils/description'
 
 interface Props {
@@ -26,7 +27,7 @@ const years = Array.from(postsByYear.entries())
 
         <ol class="relative border-l border-secondary/15 pl-5.1 lg:pl-6.2">
           {posts.map((post) => {
-            const slug = post.data.abbrlink || post.id
+            const slug = getPostSlug(post)
 
             return (
               <li class="relative pb-6.3 last:pb-0 lg:pb-8.2">

--- a/src/components/Post/AdjacentArticleNavigation.astro
+++ b/src/components/Post/AdjacentArticleNavigation.astro
@@ -4,6 +4,7 @@ import type { Post } from '@/types'
 import PostDate from '@/components/PostDate.astro'
 import { getPostPath } from '@/i18n/path'
 import { ui } from '@/i18n/ui'
+import { getPostSlug } from '@/utils/content'
 
 interface Props {
   lang: Language
@@ -44,7 +45,7 @@ const adjacentPosts = [
 
   <div class="grid mt-3.8 gap-3.4 lg:grid-cols-2 lg:gap-4">
     {adjacentPosts.map(({ label, post }) => {
-      const slug = post.data.abbrlink || post.id
+      const slug = getPostSlug(post)
 
       return (
         <a

--- a/src/components/Post/RelatedReading.astro
+++ b/src/components/Post/RelatedReading.astro
@@ -4,6 +4,7 @@ import type { Post } from '@/types'
 import PostDate from '@/components/PostDate.astro'
 import { getPostPath } from '@/i18n/path'
 import { ui } from '@/i18n/ui'
+import { getPostSlug } from '@/utils/content'
 import { getPostDescription } from '@/utils/description'
 
 interface Props {
@@ -28,7 +29,7 @@ const currentUI = ui[lang]
   <div class="mt-3.8 border border-secondary/15 rounded-3xl bg-secondary/4 px-4.6 py-4.6">
     <ul class="space-y-4.6">
       {posts.map((post) => {
-        const slug = post.data.abbrlink || post.id
+        const slug = getPostSlug(post)
 
         return (
           <li class="border-b border-secondary/12 pb-4.6 last:border-b-0 last:pb-0">

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -4,6 +4,7 @@ import type { Post } from '@/types'
 import PinIcon from '@/assets/icons/pin-icon.svg'
 import PostDate from '@/components/PostDate.astro'
 import { getPostPath } from '@/i18n/path'
+import { getPostSlug } from '@/utils/content'
 import { getPostDescription } from '@/utils/description'
 import { isHomePage } from '@/utils/page'
 
@@ -19,7 +20,7 @@ const isHome = isHomePage(Astro.url.pathname)
 
 <ul>
   {posts.map((post) => {
-    const slug = post.data.abbrlink || post.id
+    const slug = getPostSlug(post)
 
     return (
       <li

--- a/src/components/Semantic/SemanticGroupCard.astro
+++ b/src/components/Semantic/SemanticGroupCard.astro
@@ -6,6 +6,7 @@ import PostDate from '@/components/PostDate.astro'
 import SemanticKindBadge from '@/components/Semantic/SemanticKindBadge.astro'
 import { getPostPath, getSeriesPath } from '@/i18n/path'
 import { ui } from '@/i18n/ui'
+import { getPostSlug } from '@/utils/content'
 
 interface Props {
   group: PostSemanticGroup<Post>
@@ -50,7 +51,7 @@ const latestPost = group.posts.at(-1)
       <p class="mt-2.4 text-3.5 c-secondary/88 leading-1.55em cjk:text-justify">
         <span class="c-secondary/70 font-navbar">{currentUI.latest}: </span>
         <a
-          href={getPostPath(latestPost.data.abbrlink || latestPost.id, lang)}
+          href={getPostPath(getPostSlug(latestPost), lang)}
           class="transition-colors hover:c-primary"
         >
           {latestPost.data.title}

--- a/src/components/Semantic/SemanticPostSequence.astro
+++ b/src/components/Semantic/SemanticPostSequence.astro
@@ -3,6 +3,7 @@ import type { Language } from '@/i18n/config'
 import type { Post } from '@/types'
 import PostDate from '@/components/PostDate.astro'
 import { getPostPath } from '@/i18n/path'
+import { getPostSlug } from '@/utils/content'
 
 interface Props {
   posts: Post[]
@@ -23,7 +24,7 @@ const {
 
 <ol class:list={[compact ? 'space-y-2.6' : 'space-y-4.8 lg:space-y-6.2']}>
   {posts.map((post, index) => {
-    const slug = post.data.abbrlink || post.id
+    const slug = getPostSlug(post)
     const isCurrent = currentPostId === post.id
 
     return (

--- a/src/pages/[...lang]/posts/[slug].astro
+++ b/src/pages/[...lang]/posts/[slug].astro
@@ -13,7 +13,7 @@ import CitationPreview from '@/components/Widgets/CitationPreview.astro'
 import TOC from '@/components/Widgets/TOC.astro'
 import { getLangFromLocale } from '@/i18n/lang'
 import Layout from '@/layouts/Layout.astro'
-import { getAdjacentPosts, getPostPath, getPostStaticPaths, getRelatedPosts, getSemanticGroup } from '@/utils/content'
+import { getAdjacentPosts, getPostPath, getPostSlug, getPostStaticPaths, getRelatedPosts, getSemanticGroup } from '@/utils/content'
 import { getPostDescription } from '@/utils/description'
 import '@/styles/citation.css'
 
@@ -28,7 +28,7 @@ interface Props {
 
 const { post, supportedLangs } = Astro.props
 const currentLang = getLangFromLocale(Astro.currentLocale)
-const slug = post.data.abbrlink || post.id
+const slug = getPostSlug(post)
 const description = getPostDescription(post, 'meta')
 const markdownExportPath = getPostPath(slug, currentLang, 'markdown')
 const { Content, headings, remarkPluginFrontmatter } = await render(post)

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -7,6 +7,7 @@ import { allLocales, base, defaultLocale } from '@/config'
 import { getLangRouteParam } from '@/i18n/lang'
 import { memoize } from '@/utils/cache'
 import { buildRelatedPosts, buildSemanticGroups } from '@/utils/content-semantics'
+import { getPairedPostSlug } from '@/utils/post-pairing'
 
 const metaCache = new Map<string, { minutes: number, hasCitations: boolean, hasCitationPreview: boolean }>()
 
@@ -48,7 +49,7 @@ async function addMetaToPost(post: CollectionEntry<'posts'>): Promise<Post> {
 }
 
 export function getPostSlug(post: CollectionEntry<'posts'>) {
-  return post.data.abbrlink || post.id
+  return getPairedPostSlug(post)
 }
 
 export function getPostPath(
@@ -77,7 +78,7 @@ export async function checkPostSlugDuplication(posts: CollectionEntry<'posts'>[]
 
   posts.forEach((post) => {
     const lang = post.data.lang
-    const slug = post.data.abbrlink || post.id
+    const slug = getPostSlug(post)
 
     let slugSet = slugMap.get(lang)
     if (!slugSet) {

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -9,6 +9,7 @@ import sanitizeHtml from 'sanitize-html'
 import { base, defaultLocale, themeConfig } from '@/config'
 import { ui } from '@/i18n/ui'
 import { renderStaticCitationHtml } from '@/utils/citation'
+import { getPostSlug } from '@/utils/content'
 import { getPostDescription } from '@/utils/description'
 import { getAbsolutePostImageUrl } from '@/utils/post-assets'
 
@@ -112,7 +113,7 @@ export async function generateFeed({ lang }: { lang?: Language } = {}) {
 
   // Add posts to feed
   for (const post of recentPosts) {
-    const slug = post.data.abbrlink || post.id
+    const slug = getPostSlug(post)
     const link = new URL(`posts/${slug}/`, siteURL).toString()
 
     // Optimize content processing

--- a/src/utils/post-pairing.test.ts
+++ b/src/utils/post-pairing.test.ts
@@ -1,0 +1,43 @@
+/* eslint-disable test/no-import-node-test */
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { getPairedPostKey, getPairedPostSiblingCandidatePaths, getPairedPostSlug } from './post-pairing'
+
+test('getPairedPostSlug falls back to the shared pair stem for localized posts without abbrlink', () => {
+  assert.equal(getPairedPostSlug({
+    id: 'notes/hello-world-en',
+    data: { abbrlink: '' },
+  }), 'notes/hello-world')
+  assert.equal(getPairedPostSlug({
+    id: 'notes/hello-world-zh',
+    data: { abbrlink: '' },
+  }), 'notes/hello-world')
+})
+
+test('getPairedPostSlug prefers an explicit shared abbrlink when present', () => {
+  assert.equal(getPairedPostSlug({
+    id: 'notes/hello-world-en',
+    data: { abbrlink: 'hello-world' },
+  }), 'hello-world')
+})
+
+test('getPairedPostKey strips markdown extensions and locale suffixes consistently', () => {
+  assert.equal(getPairedPostKey('src/content/posts/site/hello-world-en.md'), 'src/content/posts/site/hello-world')
+  assert.equal(getPairedPostKey('src/content/posts/site/hello-world-zh.mdx'), 'src/content/posts/site/hello-world')
+  assert.equal(getPairedPostKey('src/content/posts/site/universal-post'), 'src/content/posts/site/universal-post')
+})
+
+test('getPairedPostSiblingCandidatePaths enumerates the shared pair candidates from one source path', () => {
+  assert.deepEqual(
+    getPairedPostSiblingCandidatePaths('/tmp/notes/hello-world-en.md'),
+    [
+      '/tmp/notes/hello-world.md',
+      '/tmp/notes/hello-world.mdx',
+      '/tmp/notes/hello-world-en.md',
+      '/tmp/notes/hello-world-en.mdx',
+      '/tmp/notes/hello-world-zh.md',
+      '/tmp/notes/hello-world-zh.mdx',
+    ],
+  )
+})

--- a/src/utils/post-pairing.ts
+++ b/src/utils/post-pairing.ts
@@ -1,0 +1,48 @@
+import type { Language } from '../i18n/config'
+import { langMap } from '../i18n/config'
+
+export interface PostSlugSource {
+  id: string
+  data: {
+    abbrlink?: string | null
+  }
+}
+
+const pairedPostLanguages = Object.keys(langMap) as Language[]
+const localePatternSource = pairedPostLanguages
+  .slice()
+  .sort((left, right) => right.length - left.length)
+  .map(lang => lang.replace('-', '\\-'))
+  .join('|')
+const markdownExtensionPattern = /\.(?:md|mdx)$/i
+const localeSuffixPattern = new RegExp(`-(${localePatternSource})$`)
+
+export function normalizeContentPath(value: string) {
+  return value.replace(/\\/g, '/')
+}
+
+export function getPairedPostKey(idOrPath: string) {
+  return normalizeContentPath(idOrPath)
+    .replace(markdownExtensionPattern, '')
+    .replace(localeSuffixPattern, '')
+}
+
+export function getPairedPostSiblingCandidatePaths(idOrPath: string) {
+  const pairKey = getPairedPostKey(idOrPath)
+  return [
+    `${pairKey}.md`,
+    `${pairKey}.mdx`,
+    ...pairedPostLanguages.flatMap(lang => [
+      `${pairKey}-${lang}.md`,
+      `${pairKey}-${lang}.mdx`,
+    ]),
+  ]
+}
+
+export function getPairedPostSlug(post: PostSlugSource) {
+  const abbrlink = typeof post.data.abbrlink === 'string'
+    ? post.data.abbrlink.trim()
+    : ''
+
+  return abbrlink || getPairedPostKey(post.id)
+}


### PR DESCRIPTION
## Summary
- add paired zh/en site-post scaffolding through `pnpm new-post --paired`
- centralize paired-post key, shared slug fallback, and sibling candidate derivation in `src/utils/post-pairing.ts`
- update lint and runtime consumers to reuse the same paired-post contract instead of ad hoc `abbrlink || id` logic

## Scope
- extend the authoring script and add regression coverage for paired post creation
- align `scripts/lib/post-lint.ts` and runtime helpers in `src/utils/content.ts` around the shared paired-post contract
- update affected post routing/feed/discovery components to consume `getPostSlug`
- keep new frontmatter fields, locale-specific slugs, and translation-state metadata out of scope

## Validation
- `node --import tsx --test scripts/lib/post-lint.test.ts scripts/new-post.test.ts src/utils/post-pairing.test.ts src/utils/content-semantics.test.ts`
- `pnpm verify:repo`

## Issue Links
- Parent: `#64`
- Sub-issues: `#78`, `#79`

## Risks and Follow-ups
- OG image generation still indexes pages by `post.id` rather than the shared route slug; that boundary is unchanged here and can be handled separately if the repository later wants fully unified slug-based asset addressing
