### PR TITLE
seo: strengthen canonical metadata for indexable pages

### DIFF
--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -21,6 +21,16 @@ interface Translation {
   kindSeries: string
   kindTimeline: string
   kindEvergreen: string
+  seo: {
+    homeTitle: string
+    homeDescription: string
+    aboutTitle: string
+    aboutDescription: string
+    tagsTitle: string
+    tagsDescription: string
+    tagTitle: (tag: string) => string
+    tagDescription: (tag: string, count: number) => string
+  }
 }
 
 export const ui: Record<Language, Translation> = {
@@ -45,6 +55,16 @@ export const ui: Record<Language, Translation> = {
     kindSeries: 'Series',
     kindTimeline: 'Timeline',
     kindEvergreen: 'Evergreen',
+    seo: {
+      homeTitle: 'Software engineering, AI, product thinking, and durable systems',
+      homeDescription: 'Essays and project notes on software engineering, AI tools, product thinking, and work worth compounding over time.',
+      aboutTitle: 'About Code4Focus',
+      aboutDescription: 'Learn what Code4Focus writes about, how the site is built, and why the blog emphasizes speed, clarity, and long-term craft.',
+      tagsTitle: 'Tags and topics',
+      tagsDescription: 'Browse tags across software engineering, AI, product thinking, and related notes published on Code4Focus.',
+      tagTitle: tag => `Tag: ${tag}`,
+      tagDescription: (tag, count) => `Browse ${count} ${count === 1 ? 'post' : 'posts'} tagged ${tag} on Code4Focus.`,
+    },
   },
   zh: {
     title: 'Code4Focus',
@@ -67,5 +87,15 @@ export const ui: Record<Language, Translation> = {
     kindSeries: '系列',
     kindTimeline: '时间线',
     kindEvergreen: '长青',
+    seo: {
+      homeTitle: '软件工程、AI 与长期积累',
+      homeDescription: '这里记录软件开发、AI 工具、产品思考，以及那些值得长期投入、反复打磨的事情。',
+      aboutTitle: '关于 Code4Focus',
+      aboutDescription: '了解 Code4Focus 的写作方向、建站方式，以及这个站点为何强调速度、清晰表达与长期主义。',
+      tagsTitle: '标签与主题',
+      tagsDescription: '按标签浏览软件工程、AI、产品思考与相关记录。',
+      tagTitle: tag => `标签：${tag}`,
+      tagDescription: (tag, count) => `浏览标签「${tag}」下的 ${count} 篇文章，内容涵盖软件工程、AI、产品思考等主题。`,
+    },
   },
 }

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -1,14 +1,17 @@
 ---
 import type { Language } from '@/i18n/config'
+import type { JsonLdNode } from '@/utils/seo'
 import { ClientRouter } from 'astro:transitions'
 import katexCSS from 'katex/dist/katex.min.css?url'
-import { allLocales, base, defaultLocale, themeConfig } from '@/config'
+import { base, defaultLocale, themeConfig } from '@/config'
 import { langMap } from '@/i18n/config'
 import { getNextLangPath } from '@/i18n/path'
 import { ui } from '@/i18n/ui'
 import { getPageInfo } from '@/utils/page'
 
 interface Props {
+  pageTitle?: string
+  pageDescription?: string
   postTitle?: string
   postDescription?: string
   postSlug?: string
@@ -16,11 +19,14 @@ interface Props {
   postPublished?: Date
   postUpdated?: Date
   postTags?: string[]
+  structuredData?: JsonLdNode[]
   supportedLangs?: Language[]
 }
 
 // Props and Language
 const {
+  pageTitle,
+  pageDescription,
   postTitle,
   postDescription,
   postSlug,
@@ -28,6 +34,7 @@ const {
   postPublished,
   postUpdated,
   postTags = [],
+  structuredData = [],
   supportedLangs = [],
 } = Astro.props
 const { currentLang } = getPageInfo(Astro.url.pathname)
@@ -64,9 +71,10 @@ const siteDescription = i18nTitle ? currentUI.description : description
 
 // Page Metadata
 const siteOrigin = Astro.site ?? new URL(themeConfig.site.url)
-const canonicalUrl = new URL(`${Astro.url.pathname}${Astro.url.search}`, siteOrigin).toString()
-const pageTitle = postTitle ? `${postTitle} | ${siteTitle}` : `${siteTitle} - ${siteSubtitle}`
-const pageDescription = postDescription || siteDescription
+const canonicalUrl = new URL(Astro.url.pathname, siteOrigin).toString()
+const titleSegment = postTitle ?? pageTitle
+const resolvedPageTitle = titleSegment ? `${titleSegment} | ${siteTitle}` : `${siteTitle} - ${siteSubtitle}`
+const resolvedPageDescription = postDescription ?? pageDescription ?? siteDescription
 const feedPrefix = currentLang === defaultLocale ? '' : `/${currentLang}`
 const rssFeedUrl = new URL(`${base}${feedPrefix}/rss.xml`, siteOrigin).toString()
 const atomFeedUrl = new URL(`${base}${feedPrefix}/atom.xml`, siteOrigin).toString()
@@ -83,14 +91,17 @@ const publisherLogo = favicon.startsWith('http')
   : new URL(`${base}${favicon}`, siteOrigin).toString()
 const localeCode = langMap[currentLang][0]
 const openGraphLocale = localeCode.replace('-', '_')
-const alternateLangs = (supportedLangs.length > 0 ? supportedLangs : allLocales)
-  .filter((lang, index, langs) => langs.indexOf(lang) === index)
-const alternateLinks = alternateLangs.map(lang => ({
-  lang,
-  href: new URL(getNextLangPath(Astro.url.pathname, currentLang, lang), siteOrigin).toString(),
-  hrefLang: langMap[lang][0],
-}))
-const defaultAlternate = alternateLinks.find(link => link.lang === defaultLocale) ?? alternateLinks[0]
+const normalizedSupportedLangs = supportedLangs.length > 0
+  ? [...new Set([...supportedLangs, currentLang])]
+  : []
+const alternateLinks = normalizedSupportedLangs.length > 1
+  ? normalizedSupportedLangs.map(lang => ({
+      lang,
+      href: new URL(getNextLangPath(Astro.url.pathname, currentLang, lang), siteOrigin).toString(),
+      hrefLang: langMap[lang][0],
+    }))
+  : []
+const defaultAlternate = alternateLinks.find(link => link.lang === defaultLocale) ?? alternateLinks[0] ?? null
 const isArticle = Boolean(postTitle && postPublished)
 const articleUpdated = postUpdated ?? postPublished
 const articleJsonLd = isArticle && postPublished
@@ -98,7 +109,7 @@ const articleJsonLd = isArticle && postPublished
       '@context': 'https://schema.org',
       '@type': 'BlogPosting',
       'headline': postTitle,
-      'description': pageDescription,
+      'description': resolvedPageDescription,
       'url': canonicalUrl,
       'mainEntityOfPage': {
         '@type': 'WebPage',
@@ -124,6 +135,10 @@ const articleJsonLd = isArticle && postPublished
       'isAccessibleForFree': true,
     }
   : null
+const structuredDataNodes = [
+  ...structuredData,
+  ...(articleJsonLd ? [articleJsonLd] : []),
+]
 ---
 
 <head>
@@ -133,8 +148,8 @@ const articleJsonLd = isArticle && postPublished
 {favicon.toLowerCase().endsWith('.svg') && <link rel="icon" type="image/svg+xml" href={`${base}${favicon}`} />}
 {favicon.toLowerCase().endsWith('.png') && <link rel="icon" type="image/png" href={`${base}${favicon}`} />}
 {favicon.toLowerCase().endsWith('.ico') && <link rel="icon" type="image/x-icon" href={`${base}${favicon}`} />}
-<title>{pageTitle}</title>
-<meta name="description" content={pageDescription} />
+<title>{resolvedPageTitle}</title>
+<meta name="description" content={resolvedPageDescription} />
 <meta name="author" content={author} />
 <meta name="generator" content={Astro.generator} />
 <meta name="theme-color" content={metaTheme} />
@@ -177,11 +192,11 @@ const articleJsonLd = isArticle && postPublished
 {alternateLinks
   .filter(link => link.lang !== currentLang)
   .map(link => <meta property="og:locale:alternate" content={link.hrefLang.replace('-', '_')} />)}
-<meta property="og:title" content={pageTitle} />
-<meta property="og:description" content={pageDescription} />
+<meta property="og:title" content={resolvedPageTitle} />
+<meta property="og:description" content={resolvedPageDescription} />
 <meta property="og:image" content={pageImage} />
-<meta name="twitter:title" content={pageTitle} />
-<meta name="twitter:description" content={pageDescription} />
+<meta name="twitter:title" content={resolvedPageTitle} />
+<meta name="twitter:description" content={resolvedPageDescription} />
 <meta name="twitter:image" content={pageImage} />
 <meta name="twitter:card" content="summary_large_image" />
 {twitterID && <meta name="twitter:site" content={twitterID} />}
@@ -190,7 +205,13 @@ const articleJsonLd = isArticle && postPublished
 {isArticle && postPublished && <meta property="article:published_time" content={postPublished.toISOString()} />}
 {isArticle && articleUpdated && <meta property="article:modified_time" content={articleUpdated.toISOString()} />}
 {postTags.map(tag => <meta property="article:tag" content={tag} />)}
-{articleJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />}
+{structuredDataNodes.length > 0 && (
+  <script
+    is:inline
+    type="application/ld+json"
+    set:html={JSON.stringify(structuredDataNodes.length === 1 ? structuredDataNodes[0] : structuredDataNodes)}
+  />
+)}
 
 <!-- Site Verification -->
 {google && <meta name="google-site-verification" content={google} />}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import type { Language } from '@/i18n/config'
+import type { JsonLdNode } from '@/utils/seo'
 import Button from '@/components/Button.astro'
 import Footer from '@/components/Footer.astro'
 import Header from '@/components/Header.astro'
@@ -21,6 +22,8 @@ import '@/styles/markdown.css'
 import '@/styles/transition.css'
 
 interface Props {
+  pageTitle?: string
+  pageDescription?: string
   postTitle?: string
   postDescription?: string
   postSlug?: string
@@ -28,10 +31,13 @@ interface Props {
   postPublished?: Date
   postUpdated?: Date
   postTags?: string[]
+  structuredData?: JsonLdNode[]
   supportedLangs?: Language[]
 }
 
 const {
+  pageTitle,
+  pageDescription,
   postTitle,
   postDescription,
   postSlug,
@@ -39,6 +45,7 @@ const {
   postPublished,
   postUpdated,
   postTags,
+  structuredData = [],
   supportedLangs = [],
 } = Astro.props
 const { isPost } = getPageInfo(Astro.url.pathname)
@@ -56,6 +63,8 @@ const MarginBottom = isPost && themeConfig.comment.enabled
   ]}
 >
   <Head
+    {pageTitle}
+    {pageDescription}
     {postTitle}
     {postDescription}
     {postSlug}
@@ -63,6 +72,7 @@ const MarginBottom = isPost && themeConfig.comment.enabled
     {postPublished}
     {postUpdated}
     {postTags}
+    {structuredData}
     {supportedLangs}
   />
   <body>

--- a/src/pages/[...lang]/about.astro
+++ b/src/pages/[...lang]/about.astro
@@ -1,8 +1,11 @@
 ---
 import { getCollection, render } from 'astro:content'
-import { allLocales } from '@/config'
+import { allLocales, themeConfig } from '@/config'
 import { getLangFromLocale, getLangRouteParam } from '@/i18n/lang'
+import { getLocalizedPath } from '@/i18n/path'
+import { ui } from '@/i18n/ui'
 import Layout from '@/layouts/Layout.astro'
+import { createBreadcrumbSchema, createWebPageSchema, getSiteOrigin } from '@/utils/seo'
 
 export async function getStaticPaths() {
   return allLocales.map(lang => ({
@@ -11,14 +14,36 @@ export async function getStaticPaths() {
 }
 
 const currentLang = getLangFromLocale(Astro.currentLocale)
+const currentUI = ui[currentLang]
 // Get about page content with different language
 const allAboutEntries = await getCollection('about')
 const aboutEntry = allAboutEntries.find(entry => entry.data.lang === currentLang)
   ?? allAboutEntries.find(entry => entry.data.lang === '')
 const { Content } = aboutEntry ? await render(aboutEntry) : { Content: null }
+const siteOrigin = getSiteOrigin(Astro.site ?? themeConfig.site.url)
+const pageDescription = currentUI.seo.aboutDescription
+const structuredData = [
+  createWebPageSchema({
+    type: 'AboutPage',
+    name: currentUI.seo.aboutTitle,
+    description: pageDescription,
+    path: Astro.url.pathname,
+    lang: currentLang,
+    siteOrigin,
+  }),
+  createBreadcrumbSchema([
+    { name: currentUI.title, path: getLocalizedPath('/', currentLang) },
+    { name: currentUI.about, path: Astro.url.pathname },
+  ], siteOrigin),
+]
 ---
 
-<Layout>
+<Layout
+  pageTitle={currentUI.seo.aboutTitle}
+  pageDescription={pageDescription}
+  structuredData={structuredData}
+  supportedLangs={allLocales}
+>
   <!-- Decorative Line -->
   <div class="uno-decorative-line" />
   <!-- About Page Content -->

--- a/src/pages/[...lang]/index.astro
+++ b/src/pages/[...lang]/index.astro
@@ -1,10 +1,12 @@
 ---
 import HomeTimeline from '@/components/HomeTimeline.astro'
 import PostList from '@/components/PostList.astro'
-import { allLocales } from '@/config'
+import { allLocales, themeConfig } from '@/config'
 import { getLangFromLocale, getLangRouteParam } from '@/i18n/lang'
+import { ui } from '@/i18n/ui'
 import Layout from '@/layouts/Layout.astro'
 import { getPinnedPosts, getPostsByYear } from '@/utils/content'
+import { createItemListSchema, createPostListItems, createWebSiteSchema, getSiteOrigin } from '@/utils/seo'
 
 export async function getStaticPaths() {
   return allLocales.map(lang => ({
@@ -13,11 +15,30 @@ export async function getStaticPaths() {
 }
 
 const currentLang = getLangFromLocale(Astro.currentLocale)
+const currentUI = ui[currentLang]
 const pinnedPosts = await getPinnedPosts(currentLang)
 const postsByYear = await getPostsByYear(currentLang)
+const listedPosts = [...pinnedPosts, ...Array.from(postsByYear.values()).flat()]
+const siteOrigin = getSiteOrigin(Astro.site ?? themeConfig.site.url)
+const structuredData = [
+  createWebSiteSchema({
+    name: currentUI.title,
+    description: currentUI.seo.homeDescription,
+    lang: currentLang,
+    siteOrigin,
+  }),
+  ...(listedPosts.length > 0
+    ? [createItemListSchema(createPostListItems(listedPosts, currentLang), siteOrigin, currentUI.posts)]
+    : []),
+]
 ---
 
-<Layout>
+<Layout
+  pageTitle={currentUI.seo.homeTitle}
+  pageDescription={currentUI.seo.homeDescription}
+  structuredData={structuredData}
+  supportedLangs={allLocales}
+>
   <!-- Pinned Posts -->
   {pinnedPosts.length > 0 && (
     <section class="mb-7.5">

--- a/src/pages/[...lang]/tags/[tag].astro
+++ b/src/pages/[...lang]/tags/[tag].astro
@@ -1,10 +1,13 @@
 ---
 import PostList from '@/components/PostList.astro'
 import TagList from '@/components/TagList.astro'
-import { allLocales } from '@/config'
+import { allLocales, themeConfig } from '@/config'
 import { getLangFromLocale, getLangRouteParam } from '@/i18n/lang'
+import { getLocalizedPath } from '@/i18n/path'
+import { ui } from '@/i18n/ui'
 import Layout from '@/layouts/Layout.astro'
 import { getAllTags, getPostsByTag, getTagSupportedLangs } from '@/utils/content'
+import { createBreadcrumbSchema, createItemListSchema, createPostListItems, createWebPageSchema, getSiteOrigin } from '@/utils/seo'
 
 export async function getStaticPaths() {
   const paths = await Promise.all(allLocales.map(async (lang) => {
@@ -23,12 +26,39 @@ interface Props {
 
 const { tag } = Astro.props
 const currentLang = getLangFromLocale(Astro.currentLocale)
+const currentUI = ui[currentLang]
 const posts = await getPostsByTag(tag, currentLang)
 const allTags = await getAllTags(currentLang)
 const supportedLangs = await getTagSupportedLangs(tag)
+const siteOrigin = getSiteOrigin(Astro.site ?? themeConfig.site.url)
+const pageTitle = currentUI.seo.tagTitle(tag)
+const pageDescription = currentUI.seo.tagDescription(tag, posts.length)
+const structuredData = [
+  createWebPageSchema({
+    type: 'CollectionPage',
+    name: pageTitle,
+    description: pageDescription,
+    path: Astro.url.pathname,
+    lang: currentLang,
+    siteOrigin,
+  }),
+  ...(posts.length > 0
+    ? [createItemListSchema(createPostListItems(posts, currentLang), siteOrigin, pageTitle)]
+    : []),
+  createBreadcrumbSchema([
+    { name: currentUI.title, path: getLocalizedPath('/', currentLang) },
+    { name: currentUI.tags, path: getLocalizedPath('/tags', currentLang) },
+    { name: tag, path: Astro.url.pathname },
+  ], siteOrigin),
+]
 ---
 
-<Layout supportedLangs={supportedLangs}>
+<Layout
+  pageTitle={pageTitle}
+  pageDescription={pageDescription}
+  structuredData={structuredData}
+  supportedLangs={supportedLangs}
+>
   <!-- Decorative Line -->
   <div class="uno-decorative-line" />
   <!-- Tag List -->

--- a/src/pages/[...lang]/tags/index.astro
+++ b/src/pages/[...lang]/tags/index.astro
@@ -1,9 +1,12 @@
 ---
 import TagList from '@/components/TagList.astro'
-import { allLocales } from '@/config'
+import { allLocales, themeConfig } from '@/config'
 import { getLangFromLocale, getLangRouteParam } from '@/i18n/lang'
+import { getLocalizedPath } from '@/i18n/path'
+import { ui } from '@/i18n/ui'
 import Layout from '@/layouts/Layout.astro'
 import { getAllTags } from '@/utils/content'
+import { createBreadcrumbSchema, createItemListSchema, createTagListItems, createWebPageSchema, getSiteOrigin } from '@/utils/seo'
 
 export async function getStaticPaths() {
   return allLocales.map(lang => ({
@@ -12,10 +15,35 @@ export async function getStaticPaths() {
 }
 
 const currentLang = getLangFromLocale(Astro.currentLocale)
+const currentUI = ui[currentLang]
 const allTags = await getAllTags(currentLang)
+const siteOrigin = getSiteOrigin(Astro.site ?? themeConfig.site.url)
+const pageDescription = currentUI.seo.tagsDescription
+const structuredData = [
+  createWebPageSchema({
+    type: 'CollectionPage',
+    name: currentUI.seo.tagsTitle,
+    description: pageDescription,
+    path: Astro.url.pathname,
+    lang: currentLang,
+    siteOrigin,
+  }),
+  ...(allTags.length > 0
+    ? [createItemListSchema(createTagListItems(allTags, currentLang), siteOrigin, currentUI.tags)]
+    : []),
+  createBreadcrumbSchema([
+    { name: currentUI.title, path: getLocalizedPath('/', currentLang) },
+    { name: currentUI.tags, path: Astro.url.pathname },
+  ], siteOrigin),
+]
 ---
 
-<Layout>
+<Layout
+  pageTitle={currentUI.seo.tagsTitle}
+  pageDescription={pageDescription}
+  structuredData={structuredData}
+  supportedLangs={allLocales}
+>
   <!-- Decorative Line -->
   <div class="uno-decorative-line" />
   <!-- Tag List -->

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,126 @@
+import type { Language } from '@/i18n/config'
+import type { Post } from '@/types'
+import { themeConfig } from '@/config'
+import { langMap } from '@/i18n/config'
+import { getLocalizedPath, getPostPath, getTagPath } from '@/i18n/path'
+import { getPostSlug } from '@/utils/content'
+
+export type JsonLdNode = Record<string, unknown>
+
+export interface NamedPathItem {
+  name: string
+  path: string
+}
+
+interface WebPageSchemaOptions {
+  type: 'AboutPage' | 'CollectionPage'
+  name: string
+  description: string
+  path: string
+  lang: Language
+  siteOrigin: URL
+}
+
+function getLanguageCode(lang: Language) {
+  return langMap[lang][0]
+}
+
+export function getSiteOrigin(site?: URL | string) {
+  return site instanceof URL
+    ? site
+    : new URL(site ?? themeConfig.site.url)
+}
+
+export function toAbsoluteUrl(path: string, siteOrigin: URL) {
+  return new URL(path, siteOrigin).toString()
+}
+
+function getWebsiteId(lang: Language, siteOrigin: URL) {
+  return `${toAbsoluteUrl(getLocalizedPath('/', lang), siteOrigin)}#website`
+}
+
+export function createWebSiteSchema(options: {
+  name: string
+  description: string
+  lang: Language
+  siteOrigin: URL
+}): JsonLdNode {
+  const url = toAbsoluteUrl(getLocalizedPath('/', options.lang), options.siteOrigin)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    '@id': `${url}#website`,
+    'name': options.name,
+    'description': options.description,
+    'url': url,
+    'inLanguage': getLanguageCode(options.lang),
+  }
+}
+
+export function createWebPageSchema(options: WebPageSchemaOptions): JsonLdNode {
+  const url = toAbsoluteUrl(options.path, options.siteOrigin)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': options.type,
+    '@id': `${url}#webpage`,
+    'name': options.name,
+    'description': options.description,
+    'url': url,
+    'inLanguage': getLanguageCode(options.lang),
+    'isPartOf': {
+      '@id': getWebsiteId(options.lang, options.siteOrigin),
+    },
+  }
+}
+
+export function createItemListSchema(
+  items: NamedPathItem[],
+  siteOrigin: URL,
+  name?: string,
+): JsonLdNode {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    ...(name ? { name } : {}),
+    'numberOfItems': items.length,
+    'itemListOrder': 'https://schema.org/ItemListUnordered',
+    'itemListElement': items.map((item, index) => ({
+      '@type': 'ListItem',
+      'position': index + 1,
+      'name': item.name,
+      'url': toAbsoluteUrl(item.path, siteOrigin),
+    })),
+  }
+}
+
+export function createBreadcrumbSchema(
+  items: NamedPathItem[],
+  siteOrigin: URL,
+): JsonLdNode {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': items.map((item, index) => ({
+      '@type': 'ListItem',
+      'position': index + 1,
+      'name': item.name,
+      'item': toAbsoluteUrl(item.path, siteOrigin),
+    })),
+  }
+}
+
+export function createPostListItems(posts: Post[], lang: Language): NamedPathItem[] {
+  return posts.map(post => ({
+    name: post.data.title,
+    path: getPostPath(getPostSlug(post), lang),
+  }))
+}
+
+export function createTagListItems(tags: string[], lang: Language): NamedPathItem[] {
+  return tags.map(tag => ({
+    name: tag,
+    path: getTagPath(tag, lang),
+  }))
+}


### PR DESCRIPTION
## Summary
- give the home, about, and tag pages explicit metadata instead of generic site-level fallbacks
- add page-level structured data helpers and tighten canonical and hreflang output for non-article pages

## Scope
- extend the head and layout metadata inputs for page titles, descriptions, and structured data
- add `src/utils/seo.ts` and wire homepage, about, and tag routes to emit page-specific SEO output

## Validation
- `bash scripts/verify.sh`

## Issue Links
- Parent: `#61`
- Sub-issue: none

## Risks and Follow-ups
- future indexable page types will need explicit metadata and schema wiring instead of inheriting these rules automatically
