### PR TITLE
deploy: add mimeadow standalone pages pipeline

### DIFF
--- a/.github/workflows/deploy-mimeadow-pages.yml
+++ b/.github/workflows/deploy-mimeadow-pages.yml
@@ -1,0 +1,57 @@
+name: Deploy standalone pages to mimeadow
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - standalone-pages-src/**
+      - scripts/build-standalone-pages.ts
+      - .github/workflows/deploy-mimeadow-pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CLOUDFLARE_PAGES_PROJECT_NAME: mimeadow
+
+concurrency:
+  group: mimeadow-pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy-mimeadow-pages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build standalone pages
+        run: pnpm build:standalone-pages
+
+      - name: Deploy to Cloudflare Pages
+        id: deployment
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy standalone-pages-dist
+            --project-name=${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}
+            --branch=main

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build output
 dist/
+standalone-pages-dist/
 .output/
 .astro/
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Code4Focus is the source repository for the Code4Focus writing site. The project
 
 - [Primary site](https://code4focus.github.io/)
 - [Mirror](https://code4focus.pages.dev/)
+- [Standalone pages host](https://mimeadow.pages.dev/)
 
 ## Repository Scope
 
@@ -43,6 +44,16 @@ pnpm dev
 - Set `PUBLIC_SITE_URL` in your deployment environment to the primary site origin, for example `https://code4focus.github.io`.
 - This repository may also mirror the same build to `https://code4focus.pages.dev`, but GitHub Pages remains the default canonical/feed/site URL unless a separate issue changes the primary domain.
 - See [.env.example](.env.example) for the expected variable name.
+
+## Standalone Pages Publishing
+
+- `https://mimeadow.pages.dev/` is a separate Cloudflare Pages Direct Upload project for standalone self-contained HTML experiences.
+- Add source files at `standalone-pages-src/<slug>.html`.
+- Filenames are the URL contract and must use lowercase letters, numbers, and hyphens only.
+- The standalone-pages builder maps each source file to `standalone-pages-dist/<slug>/index.html`, so `standalone-pages-src/lorica.html` publishes to `https://mimeadow.pages.dev/lorica/`.
+- The builder also generates `standalone-pages-dist/index.html` as the root index for the standalone host.
+- Deployments are handled by `.github/workflows/deploy-mimeadow-pages.yml` and reuse the Cloudflare account secrets already configured for Actions.
+- This host does not participate in the blog canonical/feed configuration, does not use Git integration, and in v1 only supports single-file self-contained HTML pages.
 
 ## Attribution And License
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "complete-issues": "node --import tsx scripts/issues/complete-issues-from-json.ts",
     "pr-context": "node --import tsx scripts/pr/collect-pr-context.ts",
     "verify:repo": "bash scripts/verify.sh",
+    "build:standalone-pages": "node --import tsx scripts/build-standalone-pages.ts",
+    "test:standalone-pages": "node --import tsx --test scripts/build-standalone-pages.test.ts",
     "apply-lqip": "node --import tsx scripts/apply-lqip.ts",
     "format-posts": "node --import tsx scripts/format-posts.ts",
     "update-theme": "node --import tsx scripts/update-theme.ts"

--- a/scripts/build-standalone-pages.test.ts
+++ b/scripts/build-standalone-pages.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable test/no-import-node-test */
+
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import process from 'node:process'
+import { afterEach, test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const tempRoots: string[] = []
+const scriptsDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = dirname(scriptsDir)
+const scriptPath = join(scriptsDir, 'build-standalone-pages.ts')
+
+afterEach(async () => {
+  while (tempRoots.length > 0) {
+    const tempRoot = tempRoots.pop()
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  }
+})
+
+async function createTempRoot() {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'standalone-pages-'))
+  tempRoots.push(tempRoot)
+  await mkdir(join(tempRoot, 'standalone-pages-src'), { recursive: true })
+  return tempRoot
+}
+
+async function runBuilder(cwd: string, extraArgs: string[] = []) {
+  return execFileAsync(
+    process.execPath,
+    [
+      '--import',
+      'tsx',
+      scriptPath,
+      '--src',
+      join(cwd, 'standalone-pages-src'),
+      '--out',
+      join(cwd, 'standalone-pages-dist'),
+      ...extraArgs,
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+      },
+    },
+  )
+}
+
+test('builder copies standalone HTML into per-slug index outputs and root index', async () => {
+  const tempRoot = await createTempRoot()
+  const sourcePath = join(tempRoot, 'standalone-pages-src', 'lorica.html')
+
+  await writeFile(sourcePath, '<!DOCTYPE html><title>Lorica</title><main>lorica</main>\n', 'utf8')
+
+  const { stdout } = await runBuilder(tempRoot)
+  const pageOutput = await readFile(join(tempRoot, 'standalone-pages-dist', 'lorica', 'index.html'), 'utf8')
+  const rootIndex = await readFile(join(tempRoot, 'standalone-pages-dist', 'index.html'), 'utf8')
+
+  assert.equal(pageOutput, '<!DOCTYPE html><title>Lorica</title><main>lorica</main>\n')
+  assert.match(rootIndex, /href="\.\/lorica\/"/)
+  assert.match(rootIndex, />lorica</)
+  assert.match(stdout, /Built 1 standalone page/)
+})
+
+test('builder preserves multiple pages and sorts them in the generated root index', async () => {
+  const tempRoot = await createTempRoot()
+
+  await writeFile(join(tempRoot, 'standalone-pages-src', 'zeta.html'), '<main>zeta</main>\n', 'utf8')
+  await writeFile(join(tempRoot, 'standalone-pages-src', 'alpha.html'), '<main>alpha</main>\n', 'utf8')
+
+  await runBuilder(tempRoot)
+
+  const rootIndex = await readFile(join(tempRoot, 'standalone-pages-dist', 'index.html'), 'utf8')
+  const alphaOutput = await readFile(join(tempRoot, 'standalone-pages-dist', 'alpha', 'index.html'), 'utf8')
+  const zetaOutput = await readFile(join(tempRoot, 'standalone-pages-dist', 'zeta', 'index.html'), 'utf8')
+
+  assert.equal(alphaOutput, '<main>alpha</main>\n')
+  assert.equal(zetaOutput, '<main>zeta</main>\n')
+  assert.ok(rootIndex.indexOf('./alpha/') < rootIndex.indexOf('./zeta/'))
+})
+
+test('builder fails on invalid slug filenames', async () => {
+  const tempRoot = await createTempRoot()
+
+  await writeFile(join(tempRoot, 'standalone-pages-src', 'Lorica.html'), '<main>bad slug</main>\n', 'utf8')
+
+  await assert.rejects(
+    runBuilder(tempRoot),
+    (error: unknown) => {
+      const stderr = typeof error === 'object' && error !== null && 'stderr' in error
+        ? String((error as { stderr: string }).stderr)
+        : ''
+      assert.match(stderr, /Invalid standalone page slug "Lorica"/)
+      return true
+    },
+  )
+})

--- a/scripts/build-standalone-pages.ts
+++ b/scripts/build-standalone-pages.ts
@@ -1,0 +1,267 @@
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { basename, extname, join, resolve } from 'node:path'
+import process from 'node:process'
+
+interface CliOptions {
+  srcDir: string
+  outDir: string
+}
+
+const slugPattern = /^[a-z0-9-]+$/
+
+function fail(message: string): never {
+  console.error(`❌ ${message}`)
+  process.exit(1)
+}
+
+function printHelp() {
+  console.log(`Build the standalone Cloudflare Pages output directory.
+
+Usage:
+  pnpm build:standalone-pages
+  node --import tsx scripts/build-standalone-pages.ts --src standalone-pages-src --out standalone-pages-dist
+
+Options:
+  --src <path>      Source directory, default: standalone-pages-src
+  --out <path>      Output directory, default: standalone-pages-dist
+  --help            Show this help text
+`)
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    srcDir: 'standalone-pages-src',
+    outDir: 'standalone-pages-dist',
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const next = argv[index + 1]
+
+    if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    }
+
+    switch (arg) {
+      case '--src':
+        if (!next)
+          fail('Missing value for --src')
+        options.srcDir = next
+        index += 1
+        break
+      case '--out':
+        if (!next)
+          fail('Missing value for --out')
+        options.outDir = next
+        index += 1
+        break
+      default:
+        fail(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('\'', '&#39;')
+}
+
+function renderIndex(slugs: string[]) {
+  const pageCountLabel = slugs.length === 1 ? '1 page' : `${slugs.length} pages`
+  const entries = slugs.length > 0
+    ? slugs
+        .map(slug => `        <li><a href="./${encodeURIComponent(slug)}/">${escapeHtml(slug)}</a></li>`)
+        .join('\n')
+    : '        <li class="empty">No standalone pages have been published yet.</li>'
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>mimeadow standalone pages</title>
+<style>
+  :root {
+    color-scheme: light;
+    --bg: #f6f2e8;
+    --panel: rgba(255, 255, 255, 0.72);
+    --text: #191510;
+    --muted: #64594b;
+    --line: rgba(25, 21, 16, 0.12);
+    --accent: #8b4f22;
+    --accent-soft: rgba(139, 79, 34, 0.1);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    padding: 32px 20px 64px;
+    background:
+      radial-gradient(circle at top left, rgba(139, 79, 34, 0.12), transparent 32%),
+      linear-gradient(180deg, #f7f2e9 0%, #efe6d8 100%);
+    color: var(--text);
+    font-family: Iowan Old Style, Palatino Linotype, Book Antiqua, Georgia, serif;
+  }
+
+  main {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 28px;
+    border: 1px solid var(--line);
+    border-radius: 28px;
+    background: var(--panel);
+    backdrop-filter: blur(16px);
+    box-shadow: 0 16px 50px rgba(25, 21, 16, 0.08);
+  }
+
+  h1 {
+    margin: 0;
+    font-size: clamp(2.2rem, 6vw, 3.8rem);
+    line-height: 0.95;
+    letter-spacing: -0.03em;
+  }
+
+  p {
+    margin: 1rem 0 0;
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.65;
+  }
+
+  .eyebrow {
+    margin: 0 0 0.9rem;
+    color: var(--accent);
+    font: 600 0.78rem/1.2 ui-monospace, SFMono-Regular, SF Mono, Menlo, monospace;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+
+  .meta {
+    margin-top: 1.2rem;
+    color: var(--muted);
+    font: 500 0.9rem/1.4 ui-monospace, SFMono-Regular, SF Mono, Menlo, monospace;
+    letter-spacing: 0.04em;
+  }
+
+  ul {
+    list-style: none;
+    margin: 2rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  li {
+    margin: 0;
+  }
+
+  a {
+    display: block;
+    width: 100%;
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    background: white;
+    color: inherit;
+    text-decoration: none;
+    transition: transform 150ms ease, border-color 150ms ease, background-color 150ms ease;
+  }
+
+  a:hover {
+    transform: translateY(-1px);
+    border-color: rgba(139, 79, 34, 0.35);
+    background: var(--accent-soft);
+  }
+
+  .empty {
+    padding: 1rem 1.1rem;
+    border: 1px dashed var(--line);
+    border-radius: 18px;
+    color: var(--muted);
+    background: rgba(255, 255, 255, 0.42);
+  }
+</style>
+</head>
+<body>
+<main>
+  <div class="eyebrow">mimeadow.pages.dev</div>
+  <h1>Standalone Pages</h1>
+  <p>Self-contained HTML pages published from this repository to the dedicated Cloudflare Pages host.</p>
+  <div class="meta">${pageCountLabel}</div>
+  <ul>
+${entries}
+  </ul>
+</main>
+</body>
+</html>
+`
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const srcDir = resolve(process.cwd(), options.srcDir)
+  const outDir = resolve(process.cwd(), options.outDir)
+  const dirEntries = await readdir(srcDir, { withFileTypes: true }).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error)
+    fail(`Failed to read source directory "${options.srcDir}": ${message}`)
+  })
+
+  await rm(outDir, { recursive: true, force: true })
+  await mkdir(outDir, { recursive: true })
+
+  const pageEntries: Array<{ fileName: string, slug: string }> = []
+
+  for (const entry of dirEntries) {
+    if (entry.isDirectory()) {
+      fail(`Nested directories are not supported in "${options.srcDir}": ${entry.name}`)
+    }
+
+    if (!entry.isFile()) {
+      fail(`Unsupported source entry in "${options.srcDir}": ${entry.name}`)
+    }
+
+    if (extname(entry.name) !== '.html') {
+      fail(`Only .html source files are supported in "${options.srcDir}": ${entry.name}`)
+    }
+
+    const slug = basename(entry.name, '.html')
+    if (!slugPattern.test(slug)) {
+      fail(`Invalid standalone page slug "${slug}". Use lowercase letters, numbers, and hyphens only.`)
+    }
+
+    pageEntries.push({
+      fileName: entry.name,
+      slug,
+    })
+  }
+
+  pageEntries.sort((left, right) => left.slug.localeCompare(right.slug))
+
+  for (const page of pageEntries) {
+    const sourcePath = join(srcDir, page.fileName)
+    const outputDir = join(outDir, page.slug)
+    const outputPath = join(outputDir, 'index.html')
+    const source = await readFile(sourcePath, 'utf8')
+
+    await mkdir(outputDir, { recursive: true })
+    await writeFile(outputPath, source, 'utf8')
+  }
+
+  await writeFile(join(outDir, 'index.html'), renderIndex(pageEntries.map(page => page.slug)), 'utf8')
+
+  console.log(`✅ Built ${pageEntries.length} standalone page${pageEntries.length === 1 ? '' : 's'} into ${options.outDir}`)
+  for (const page of pageEntries) {
+    console.log(`- ${page.slug} -> /${page.slug}/`)
+  }
+}
+
+await main()

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -81,4 +81,5 @@ fi
 
 if [[ $run_build -eq 1 ]]; then
   run_step "astro build" ./node_modules/.bin/astro build
+  run_step "standalone pages build" pnpm build:standalone-pages
 fi

--- a/standalone-pages-src/lorica.html
+++ b/standalone-pages-src/lorica.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lorica</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --ink: #141210;
+    --ink-soft: #2a2520;
+    --paper: #ece4d3;
+    --paper-warm: #e3d9c3;
+    --gold: #8a6a2a;
+    --rust: #8a3a1f;
+    --rust-bright: #c4572e;
+    --rule: #5a4a36;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  html, body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: 'Cormorant Garamond', 'Times New Roman', serif;
+    font-weight: 400;
+    min-height: 100vh;
+    overflow-x: hidden;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+      radial-gradient(circle at 20% 30%, rgba(138, 106, 42, 0.04) 0%, transparent 50%),
+      radial-gradient(circle at 80% 70%, rgba(138, 58, 31, 0.03) 0%, transparent 50%),
+      url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence baseFrequency='0.9' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0.1 0 0 0 0 0.08 0 0 0 0 0.06 0 0 0 0.08 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+    mix-blend-mode: multiply;
+    opacity: 0.6;
+    z-index: 1;
+  }
+
+  .sheet {
+    position: relative;
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 28px 56px 36px;
+    z-index: 2;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .wordmark { text-align: center; }
+  .wordmark h1 {
+    font-family: 'Cormorant Garamond', serif;
+    font-weight: 300;
+    font-size: clamp(56px, 8.5vw, 104px);
+    letter-spacing: 0.02em;
+    line-height: 0.95;
+    color: var(--ink);
+    font-style: italic;
+    display: inline-block;
+  }
+  .wordmark h1 .dot { color: var(--rust); font-style: normal; }
+  .subtitle {
+    font-family: 'Cormorant Garamond', serif;
+    font-style: italic;
+    font-weight: 400;
+    font-size: 17px;
+    color: var(--ink-soft);
+    letter-spacing: 0.04em;
+    margin-top: 2px;
+  }
+
+  .thesis { text-align: center; margin: 36px auto 0; max-width: 820px; }
+  .thesis-mark {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9.5px;
+    letter-spacing: 0.3em;
+    color: var(--gold);
+    text-transform: uppercase;
+    margin-bottom: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+  }
+  .thesis-mark::before, .thesis-mark::after {
+    content: '';
+    width: 44px;
+    height: 1px;
+    background: var(--gold);
+    opacity: 0.5;
+  }
+  .thesis p {
+    font-family: 'Cormorant Garamond', serif;
+    font-weight: 400;
+    font-size: clamp(22px, 2.8vw, 34px);
+    line-height: 1.25;
+    color: var(--ink);
+    letter-spacing: -0.005em;
+  }
+  .thesis p em { font-style: italic; color: var(--rust); }
+  .thesis p .amp { font-style: italic; color: var(--gold); }
+
+  .canvas {
+    position: relative;
+    margin: 36px auto 0;
+    width: 100%;
+    max-width: 920px;
+    aspect-ratio: 16 / 7.5;
+    flex: 1 1 auto;
+  }
+  .canvas svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+  }
+
+  .mark-stage {
+    position: absolute;
+    left: 50%;
+    bottom: 2%;
+    transform: translateX(-50%);
+    text-align: center;
+    width: 86%;
+    max-width: 680px;
+    pointer-events: none;
+    z-index: 3;
+    height: 64px;
+  }
+  .mark {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    transform: translateX(-50%);
+    width: 100%;
+    opacity: 0;
+    animation: mark-cycle 20s ease-in-out infinite;
+  }
+  .mark .lede {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: clamp(18px, 2vw, 25px);
+    font-weight: 500;
+    font-style: italic;
+    color: var(--ink);
+    display: block;
+    line-height: 1.2;
+  }
+  .mark .gloss {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: clamp(9px, 0.9vw, 11px);
+    font-weight: 400;
+    color: var(--gold);
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    display: block;
+    margin-top: 10px;
+  }
+  .mark-1 { animation-delay: 0s; }
+  .mark-2 { animation-delay: 5s; }
+  .mark-3 { animation-delay: 10s; }
+  .mark-4 { animation-delay: 15s; }
+
+  @keyframes mark-cycle {
+    0% { opacity: 0; transform: translate(-50%, 6px); }
+    3% { opacity: 1; transform: translate(-50%, 0); }
+    22% { opacity: 1; transform: translate(-50%, 0); }
+    25% { opacity: 0; transform: translate(-50%, -4px); }
+    100% { opacity: 0; }
+  }
+
+  @keyframes breath {
+    0%, 100% { opacity: 0.8; }
+    50% { opacity: 1; }
+  }
+  @keyframes ignite {
+    0%, 60% { fill: var(--ink); }
+    65% { fill: var(--rust-bright); }
+    100% { fill: var(--rust); }
+  }
+  @keyframes ripple-out {
+    0%, 58% { r: 6; opacity: 0; }
+    62% { r: 6; opacity: 1; }
+    100% { r: 30; opacity: 0; }
+  }
+  @keyframes propagate {
+    0%, 66% { fill: #141210; stroke: none; }
+    70% { fill: transparent; stroke: #c4572e; stroke-dasharray: 2 2; stroke-width: 1.4; }
+    100% { fill: transparent; stroke: #8a3a1f; stroke-dasharray: 2 2; stroke-width: 1.2; }
+  }
+  @keyframes line-warn {
+    0%, 66% { stroke: #5a4a36; stroke-width: 1; opacity: 0.55; stroke-dasharray: 0; }
+    72% { stroke: #c4572e; stroke-width: 1.6; opacity: 1; stroke-dasharray: 0; }
+    100% { stroke: #8a3a1f; stroke-width: 1; opacity: 0.85; stroke-dasharray: 3 3; }
+  }
+  @keyframes label-dim {
+    0%, 60% { fill: #2a2520; opacity: 0.7; }
+    70% { fill: #8a3a1f; opacity: 1; }
+    100% { fill: #8a3a1f; opacity: 0.9; }
+  }
+  @keyframes label-flash {
+    0%, 60% { fill: #8a6a2a; opacity: 0.9; }
+    65% { fill: #c4572e; opacity: 1; }
+    100% { fill: #8a3a1f; opacity: 1; }
+  }
+  @keyframes fade-in {
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .g-sound { animation: breath 4s ease-in-out infinite; }
+  .g-ignite { animation: ignite 8s ease-in-out infinite; }
+  .g-ripple { animation: ripple-out 8s ease-in-out infinite; }
+  .g-claim { animation: propagate 8s ease-in-out infinite; animation-delay: 0.35s; }
+  .g-proof { animation: propagate 8s ease-in-out infinite; animation-delay: 0.70s; }
+  .g-section { animation: propagate 8s ease-in-out infinite; animation-delay: 1.00s; }
+  .g-figure { animation: propagate 8s ease-in-out infinite; animation-delay: 1.00s; }
+  .g-paper { animation: propagate 8s ease-in-out infinite; animation-delay: 1.35s; }
+
+  .g-line-1 { animation: line-warn 8s ease-in-out infinite; animation-delay: 0.15s; }
+  .g-line-2 { animation: line-warn 8s ease-in-out infinite; animation-delay: 0.50s; }
+  .g-line-3 { animation: line-warn 8s ease-in-out infinite; animation-delay: 0.80s; }
+  .g-line-4 { animation: line-warn 8s ease-in-out infinite; animation-delay: 0.80s; }
+  .g-line-5 { animation: line-warn 8s ease-in-out infinite; animation-delay: 1.15s; }
+  .g-line-6 { animation: line-warn 8s ease-in-out infinite; animation-delay: 1.15s; }
+
+  .g-label-source { animation: label-flash 8s ease-in-out infinite; }
+  .g-label-claim { animation: label-dim 8s ease-in-out infinite; animation-delay: 0.35s; }
+  .g-label-proof { animation: label-dim 8s ease-in-out infinite; animation-delay: 0.70s; }
+  .g-label-section { animation: label-dim 8s ease-in-out infinite; animation-delay: 1.00s; }
+  .g-label-figure { animation: label-dim 8s ease-in-out infinite; animation-delay: 1.00s; }
+  .g-label-paper { animation: label-dim 8s ease-in-out infinite; animation-delay: 1.35s; }
+
+  .thesis, .canvas { animation: fade-in 0.9s ease-out backwards; }
+  .canvas { animation-delay: 0.15s; }
+
+  @media (max-width: 820px) {
+    .sheet { padding: 24px 20px 32px; }
+    .canvas { aspect-ratio: auto; height: 460px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="sheet">
+
+  <section class="wordmark">
+    <h1>Lorica<span class="dot">.</span></h1>
+    <div class="subtitle">— a standing check on long work —</div>
+  </section>
+
+  <section class="thesis">
+    <div class="thesis-mark">The Commitment</div>
+    <p>
+      To ensure that what is <em>right</em> stays right <span class="amp">&amp;</span><br>
+      when it no longer does, to <em>make it known</em>.
+    </p>
+  </section>
+
+  <section class="canvas">
+    <svg viewBox="0 0 960 430" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+      <defs>
+        <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse">
+          <path d="M 36 0 L 0 0 0 36" fill="none" stroke="#5a4a36" stroke-width="0.3" opacity="0.15"/>
+        </pattern>
+        <radialGradient id="center-glow" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stop-color="#8a6a2a" stop-opacity="0.08"/>
+          <stop offset="100%" stop-color="#8a6a2a" stop-opacity="0"/>
+        </radialGradient>
+      </defs>
+
+      <rect x="30" y="60" width="900" height="260" fill="url(#center-glow)"/>
+      <rect x="60" y="80" width="840" height="240" fill="url(#grid)" opacity="0.7"/>
+
+      <g font-family="Cormorant Garamond, serif" font-style="italic" fill="#2a2520">
+        <text x="190" y="38" text-anchor="middle" font-size="13">something shifts</text>
+        <text x="800" y="38" text-anchor="middle" font-size="13">the paper learns</text>
+        <line x1="260" y1="34" x2="730" y2="34" stroke="#8a6a2a" stroke-width="0.5" opacity="0.35" stroke-dasharray="2 4"/>
+      </g>
+
+      <g font-family="JetBrains Mono, monospace" font-size="9" letter-spacing="0.22em" fill="#8a6a2a" opacity="0.85">
+        <text x="40" y="92" text-anchor="start">EVIDENCE</text>
+        <text x="40" y="258" text-anchor="start">AUTHORING</text>
+      </g>
+
+      <line x1="40" y1="98" x2="110" y2="98" stroke="#8a6a2a" stroke-width="0.5" opacity="0.4"/>
+      <line x1="40" y1="264" x2="128" y2="264" stroke="#8a6a2a" stroke-width="0.5" opacity="0.4"/>
+
+      <line class="g-line-1" x1="208" y1="135" x2="352" y2="135" stroke="#5a4a36" stroke-width="1" opacity="0.55"/>
+      <line class="g-line-2" x1="388" y1="135" x2="532" y2="135" stroke="#5a4a36" stroke-width="1" opacity="0.55"/>
+
+      <line class="g-line-3" x1="370" y1="152" x2="370" y2="282" stroke="#5a4a36" stroke-width="1" opacity="0.5"/>
+      <line class="g-line-4" x1="550" y1="152" x2="550" y2="282" stroke="#5a4a36" stroke-width="1" opacity="0.5"/>
+
+      <path class="g-line-5" d="M 388,298 Q 600,298 785,220" fill="none" stroke="#5a4a36" stroke-width="1" opacity="0.5"/>
+      <path class="g-line-6" d="M 568,298 Q 690,270 785,224" fill="none" stroke="#5a4a36" stroke-width="1" opacity="0.5"/>
+
+      <path d="M 568,135 Q 690,170 785,200" fill="none" stroke="#5a4a36" stroke-width="0.5" opacity="0.3" stroke-dasharray="3 4"/>
+
+      <circle class="g-ripple" cx="190" cy="135" r="6" fill="none" stroke="#c4572e" stroke-width="1.5" opacity="0"/>
+      <circle class="g-ripple" cx="190" cy="135" r="6" fill="none" stroke="#c4572e" stroke-width="1" opacity="0" style="animation-delay: 0.18s"/>
+
+      <g>
+        <circle class="g-ignite" cx="190" cy="135" r="16" fill="#141210"/>
+        <circle cx="190" cy="135" r="22" fill="none" stroke="#5a4a36" stroke-width="0.5" opacity="0.55"/>
+      </g>
+      <circle class="g-claim" cx="370" cy="135" r="14" fill="#141210"/>
+      <circle class="g-proof" cx="550" cy="135" r="14" fill="#141210"/>
+
+      <circle class="g-section" cx="370" cy="298" r="14" fill="#141210"/>
+      <circle class="g-figure" cx="550" cy="298" r="14" fill="#141210"/>
+
+      <g>
+        <circle class="g-paper" cx="800" cy="210" r="16" fill="#141210"/>
+        <circle cx="800" cy="210" r="22" fill="none" stroke="#5a4a36" stroke-width="0.5" opacity="0.4"/>
+      </g>
+
+      <g font-family="JetBrains Mono, monospace" font-size="10" letter-spacing="0.2em" text-anchor="middle">
+        <text class="g-label-source" x="190" y="108" fill="#2a2520">SOURCE</text>
+        <text class="g-label-claim" x="370" y="108" fill="#2a2520">CLAIM</text>
+        <text class="g-label-proof" x="550" y="108" fill="#2a2520">PROOF</text>
+        <text class="g-label-section" x="370" y="328" fill="#2a2520">SECTION</text>
+        <text class="g-label-figure" x="550" y="328" fill="#2a2520">FIGURE</text>
+        <text class="g-label-paper" x="800" y="186" fill="#2a2520">PAPER</text>
+      </g>
+
+      <g stroke="#5a4a36" stroke-width="0.5" fill="none" opacity="0.5">
+        <path d="M 16,16 L 16,30 M 16,16 L 30,16"/>
+        <path d="M 944,16 L 944,30 M 944,16 L 930,16"/>
+        <path d="M 16,414 L 16,400 M 16,414 L 30,414"/>
+        <path d="M 944,414 L 944,400 M 944,414 L 930,414"/>
+      </g>
+    </svg>
+
+    <div class="mark-stage">
+      <div class="mark mark-1">
+        <span class="lede">Correctness has a shelf life.</span>
+        <span class="gloss">keep the premises under watch</span>
+      </div>
+      <div class="mark mark-2">
+        <span class="lede">Silent failure is the only failure.</span>
+        <span class="gloss">make the quiet breakage loud</span>
+      </div>
+      <div class="mark mark-3">
+        <span class="lede">Memory lives in the workspace.</span>
+        <span class="gloss">people forget &nbsp;·&nbsp; disk remembers</span>
+      </div>
+      <div class="mark mark-4">
+        <span class="lede">The work is long.</span>
+        <span class="gloss">build accordingly</span>
+      </div>
+    </div>
+  </section>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated standalone-pages publishing path for self-contained HTML experiences hosted at `https://mimeadow.pages.dev/`
- keep the existing Astro blog deployment flow unchanged while introducing a separate Cloudflare Pages workflow for the new host
- seed the pipeline with the initial `lorica` page and document the repository contract for future standalone pages

## Scope
- add `standalone-pages-src/<slug>.html` as the repository input contract and generate `standalone-pages-dist/<slug>/index.html` plus a root index page
- add `scripts/build-standalone-pages.ts`, its focused tests, npm scripts, and repository verification coverage
- add `.github/workflows/deploy-mimeadow-pages.yml` to deploy `standalone-pages-dist/` to the `mimeadow` Cloudflare Pages project on `main`
- update README and gitignore for the new standalone-pages publishing flow

## Validation
- `pnpm test:standalone-pages`
- `bash scripts/verify.sh`

## Issue Links
- Parent: #84
- Sub-issue: #85

## Risks and Follow-ups
- the workflow assumes the Cloudflare Pages project `mimeadow` already exists as a Direct Upload project and that the existing Cloudflare secrets have access to it
- v1 only supports self-contained single-file HTML inputs; additional local asset bundles and preview deployments remain out of scope
